### PR TITLE
modules: Account for change to struct in network channel payload

### DIFF
--- a/app/src/common/message_channel.h
+++ b/app/src/common/message_channel.h
@@ -103,7 +103,7 @@ struct network_msg {
 	};
 };
 
-#define MSG_TO_NETWORK_STATUS(_msg)	(*(const enum network_msg_type *)_msg)
+#define MSG_TO_NETWORK_MSG(_msg)	(*(const struct network_msg *)_msg)
 
 enum cloud_status {
 	CLOUD_DISCONNECTED = 0x1,

--- a/app/src/modules/battery/battery.c
+++ b/app/src/modules/battery/battery.c
@@ -32,7 +32,7 @@ ZBUS_CHAN_ADD_OBS(TIME_CHAN, battery, 0);
 
 #define MAX_MSG_SIZE \
 	(MAX(sizeof(enum trigger_type), \
-		(MAX(sizeof(enum network_msg_type), sizeof(enum time_status)))))
+		(MAX(sizeof(struct network_msg), sizeof(enum time_status)))))
 
 BUILD_ASSERT(CONFIG_APP_BATTERY_WATCHDOG_TIMEOUT_SECONDS >
 			CONFIG_APP_BATTERY_EXEC_TIME_SECONDS_MAX,

--- a/app/src/modules/led/led.c
+++ b/app/src/modules/led/led.c
@@ -494,9 +494,9 @@ void led_callback(const struct zbus_channel *chan)
 	}
 
 	if (&NETWORK_CHAN == chan) {
-		const enum network_msg_type *status = zbus_chan_const_msg(chan);
+		const struct network_msg *msg = zbus_chan_const_msg(chan);
 
-		state_object.status = *status;
+		state_object.status = msg->type;
 	}
 
 	if (&LOCATION_CHAN == chan) {

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -38,7 +38,7 @@ ZBUS_CHAN_ADD_OBS(NETWORK_CHAN, location, 0);
 	(MAX(sizeof(enum trigger_type), \
 		 (MAX(sizeof(enum cloud_status), \
 		     (MAX(sizeof(struct configuration), \
-		         sizeof(enum network_msg_type)))))))
+		         sizeof(struct network_msg)))))))
 
 static bool gnss_enabled;
 static bool gnss_initialized;
@@ -99,14 +99,14 @@ void trigger_location_update(void)
 	}
 }
 
-void handle_network_chan(enum network_msg_type status) {
+void handle_network_chan(struct network_msg msg) {
 	int err = 0;
 
 	if (gnss_initialized) {
 		return;
 	}
 
-	if (status == NETWORK_CONNECTED) {
+	if (msg.type == NETWORK_CONNECTED) {
 		/* GNSS has to be enabled after the modem is initialized and enabled */
 		err = lte_lc_func_mode_set(LTE_LC_FUNC_MODE_ACTIVATE_GNSS);
 		if (err) {
@@ -208,7 +208,7 @@ void location_task(void)
 
 		if (&NETWORK_CHAN == chan) {
 			LOG_DBG("Network status received");
-			handle_network_chan(MSG_TO_NETWORK_STATUS(&msg_buf));
+			handle_network_chan(MSG_TO_NETWORK_MSG(&msg_buf));
 		}
 
 		if (&TRIGGER_CHAN == chan) {


### PR DESCRIPTION
- Update macro that casts to network messages to use the
  network_msg struct.
- Adjust the maximum stored buffer size of modules that subscribe to
  the network module.