### PR TITLE
workflows: use self-hosted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,12 @@ on:
         description: The version of the firmware built on this run_id
         value: ${{ jobs.build.outputs.version }}
 
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "tests/on_target/**"
-      - ".github/workflows/*.yml"
-      - "!.github/workflows/build.yml"
   pull_request:
     paths-ignore:
-      - "tests/on_target/**"
+      - "tests/**"
+      - "docs/**"
+      - "scripts/**"
+      - "README.md"
       - ".github/workflows/*.yml"
       - "!.github/workflows/build.yml"
   schedule:
@@ -42,7 +38,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: build_self_hosted
     container: ghcr.io/zephyrproject-rtos/ci:v0.27.4
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
@@ -58,7 +54,11 @@ jobs:
       - name: Initialize
         working-directory: asset-tracker-template
         run: |
+          if [ ! -d "../.west" ]; then
           west init -l .
+          else
+          echo ".west folder already exists, skipping west init."
+          fi
           west config manifest.group-filter +bsec
           west config build.sysbuild True
           west update -o=--depth=1 -n

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,15 +8,18 @@ on:
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-24.04
+    runs-on: build_self_hosted
     name: Run compliance checks on patch series (PR)
+    container: python:3.13.0-slim-bookworm
 
     # Skip job if it was triggered by Renovate Bot
     if: ${{ !contains(github.actor, 'renovate') }}
 
     steps:
-      - name: Pip install
+      - name: Install requirements
         run: |
+          apt-get update
+          apt-get install --no-install-recommends -y libmagic1 git
           pip install unidiff yamllint junitparser python-magic west lxml gitlint
 
       - name: Checkout the code
@@ -29,15 +32,11 @@ jobs:
       - name: Initialize
         working-directory: asset-tracker-template
         run: |
+          if [ ! -d "../.west" ]; then
           west init -l .
-          west config manifest.project-filter -- \
-            "-bsim,-wfa-qt-control-app,-mcuboot,-qcbor,-mbedtls,-oberon-psa-crypto,\
-            -nrfxlib,-trusted-firmware-m,-psa-arch-tests,-matter,-cjson,-azure-sdk-for-c,\
-            -cirrus,-openthread,-suit-generator,-suit-processor,-cmock,-memfault-firmware-sdk,\
-            -canopennode,-chre,-lz4,-nanopb,-tf-m-tests,-zscilib,-cmsis-dsp,-cmsis-nn,-hostap,\
-            -liblc3,-loramac-node,-lvgl,-nrf_hw_models,-nrf_wifi,-open-amp,-picolibc,-uoscore-uedhoc,\
-            -zcbor,-soc-hwmv1,-coremark,-cmsis,-edtt,-fatfs,-hal_nordic,-hal_st,-hal_wurthelektronik,\
-            -libmetal,-littlefs,-mipi-sys-t,-net-tools,-segger,-tinycrypt"
+          else
+          echo ".west folder already exists, skipping west init."
+          fi
           west update -o=--depth=1 -n
 
       - name: Run Compliance Tests

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: ubuntu-latest
+    runs-on: build_self_hosted
     container: ghcr.io/zephyrproject-rtos/ci:v0.27.4
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
@@ -39,7 +39,11 @@ jobs:
       - name: Initialize
         working-directory: asset-tracker-template
         run: |
+            if [ ! -d "../.west" ]; then
             west init -l .
+            else
+            echo ".west folder already exists, skipping west init."
+            fi
             west config manifest.group-filter +bsec
             west config build.sysbuild True
             west update -o=--depth=1 -n

--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -43,8 +43,7 @@ jobs:
     strategy:
       matrix:
         # nrf9151dk not available yet
-        # device: [thingy91x, nrf9151dk]
-        device: [thingy91x]
+        device: [cia-trd-thingy91x]
 
     # Self-hosted runner is labeled according to the device it is linked with
     runs-on: ${{ matrix.device }}


### PR DESCRIPTION
Use self-hosted runners for double reason.
CI on PR becomes very fast, no docker pull and west update.
Also running out of github runners usage for private repo.