### PR TITLE
modules: Fix initialization of state objects

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -669,7 +669,7 @@ int main(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct main_state main_state;
+	struct main_state main_state = { 0 };
 
 	main_state.interval_sec = CONFIG_APP_MODULE_TRIGGER_TIMEOUT_SECONDS;
 

--- a/app/src/modules/cloud/cloud_module.c
+++ b/app/src/modules/cloud/cloud_module.c
@@ -704,7 +704,7 @@ static void cloud_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_CLOUD_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct cloud_state cloud_state;
+	struct cloud_state cloud_state = { 0 };
 
 	LOG_DBG("cloud  module task started");
 

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -151,7 +151,7 @@ static void environmental_task(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_ENVIRONMENTAL_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct environmental_state environmental_state;
+	struct environmental_state environmental_state = { 0 };
 
 	LOG_DBG("Environmental module task started");
 

--- a/app/src/modules/led/led.c
+++ b/app/src/modules/led/led.c
@@ -38,7 +38,7 @@ static const struct pwm_dt_spec pwm_led2 = PWM_DT_SPEC_GET(PWM_LED2);
 /* Register log module */
 LOG_MODULE_REGISTER(led, CONFIG_APP_LED_LOG_LEVEL);
 
-void led_callback(const struct zbus_channel *chan);
+static void led_callback(const struct zbus_channel *chan);
 
 /* Register listener - led_callback will be called everytime a channel that the module listens on
  * receives a new message.
@@ -131,7 +131,7 @@ static void blink_timer_handler(struct k_work *work)
 }
 
 /* Function called when there is a message received on a channel that the module listens to */
-void led_callback(const struct zbus_channel *chan)
+static void led_callback(const struct zbus_channel *chan)
 {
 	if (&LED_CHAN == chan) {
 		const struct led_msg *led_msg = zbus_chan_const_msg(chan);

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -144,7 +144,7 @@ static void location_print_data_details(enum location_method method,
 #endif
 }
 
-void location_task(void)
+static void location_task(void)
 {
 	int err = 0;
 	const struct zbus_channel *chan;


### PR DESCRIPTION
After state objects were made local and not static anymore, they need to be zero-initialized.