### PR TITLE
workflows: fix memfault elf upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault-att.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault-att.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}\" >> overlay-memfault-att.conf
-          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault-att.conf
+          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}-thingy91x\" >> overlay-memfault-att.conf
           west build -b thingy91x/nrf9151/ns -d build -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault-att.conf"
           cp build/merged.hex artifacts/asset-tracker-template-${{ env.VERSION }}-thingy91x-nrf91.hex
           cp build/app/zephyr/.config artifacts/asset-tracker-template-${{ env.VERSION }}-thingy91x-nrf91.config
@@ -122,7 +122,7 @@ jobs:
           echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault-att.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault-att.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}\" >> overlay-memfault-att.conf
-          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault-att.conf
+          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}-nrf9151dk\" >> overlay-memfault-att.conf
           west build -b nrf9151dk/nrf9151/ns -d build -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault-att.conf"
           cp build/merged.hex artifacts/asset-tracker-template-${{ env.VERSION }}-nrf9151dk-nrf91.hex
           cp build/app/zephyr/.config artifacts/asset-tracker-template-${{ env.VERSION }}-nrf9151dk-nrf91.config
@@ -153,7 +153,7 @@ jobs:
           echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault-debug.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault-debug.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}-debug\" >> overlay-memfault-debug.conf
-          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault-debug.conf
+          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}-thingy91x\" >> overlay-memfault-debug.conf
           west build -p -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault-debug.conf;overlay-etb.conf"
 
       - name: Rename debug artifacts

--- a/.github/workflows/publish-symbol-files-to-memfault.yml
+++ b/.github/workflows/publish-symbol-files-to-memfault.yml
@@ -40,7 +40,7 @@ jobs:
               --org ${{ vars.MEMFAULT_ORGANIZATION_SLUG }} \
               --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
               upload-mcu-symbols \
-              --software-type asset-tracker-template \
+              --software-type asset-tracker-template-thingy91x \
               --software-version ${{ inputs.version }} \
               asset-tracker-template-${{ inputs.version }}-thingy91x-nrf91.elf
 
@@ -49,7 +49,7 @@ jobs:
               --org ${{ vars.MEMFAULT_ORGANIZATION_SLUG }} \
               --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
               upload-mcu-symbols \
-              --software-type asset-tracker-template \
+              --software-type asset-tracker-template-nrf9151dk \
               --software-version ${{ inputs.version }} \
               asset-tracker-template-${{ inputs.version }}-nrf9151dk-nrf91.elf
 
@@ -61,6 +61,6 @@ jobs:
               --org ${{ vars.MEMFAULT_ORGANIZATION_SLUG }} \
               --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
               upload-mcu-symbols \
-              --software-type asset-tracker-template \
+              --software-type asset-tracker-template-thingy91x \
               --software-version ${{ inputs.version }}-debug \
               asset-tracker-template-${{ inputs.version }}-debug-thingy91x-nrf91.elf

--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -104,7 +104,7 @@ jobs:
               --org ${{ vars.MEMFAULT_ORGANIZATION_SLUG }} \
               --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
               upload-mcu-symbols \
-              --software-type asset-tracker-template-ci \
+              --software-type asset-tracker-template-ci-${{ matrix.device }} \
               --software-version ${{ inputs.artifact_fw_version }} \
               asset-tracker-template-${{ inputs.artifact_fw_version }}-${{ matrix.device }}-nrf91.elf
 


### PR DESCRIPTION
9151dk and thingy91x are currently racing for memfault upload. This should fix it.