### PR TITLE
ci: use test docker 1.0.1

### DIFF
--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -58,7 +58,7 @@ jobs:
       packages: read
 
     container:
-      image: ghcr.io/nordicsemiconductor/asset-tracker-template:test-docker-v1.0.0
+      image: ghcr.io/nrfconnect/asset-tracker-template:test-docker-v1.0.1
       options: --privileged
       volumes:
         - /dev:/dev:rw

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -6,7 +6,7 @@ NOTE: The tests have been tested on Ubuntu 22.04. For details on how to install 
 
 ### Setup docker
 ```shell
-docker pull ghcr.io/nordicsemiconductor/asset-tracker-template:test-docker-v1.0.0
+docker pull ghcr.io/nrfconnect/asset-tracker-template:test-docker-v1.0.1
 cd <path_to_att_dir>
 docker run --rm -it \
   --privileged \
@@ -14,7 +14,7 @@ docker run --rm -it \
   -v /run/udev:/run/udev \
   -v .:/work/asset-tracker-template \
   -v /opt/setup-jlink:/opt/setup-jlink \
-  ghcr.io/nordicsemiconductor/asset-tracker-template:test-docker-v1.0.0 \
+  ghcr.io/nrfconnect/asset-tracker-template:test-docker-v1.0.1 \
   /bin/bash
 cd asset-tracker-template/tests/on_target
 ```


### PR DESCRIPTION
1.0.0 points to old github org.
Fix it with 1.0.1.