### PR TITLE
main: dont crash if cbor decoding fails

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -461,7 +461,6 @@ static void triggering_run(void *o)
 								     &state_object->interval_sec);
 			if (err) {
 				LOG_ERR("get_update_interval_from_cbor_response, error: %d", err);
-				SEND_FATAL_ERROR();
 				return;
 			}
 


### PR DESCRIPTION
If configs coming from the cloud are malformed, cbor decoding fails. Device then bootloops. This is a temporary fix for that.