### PR TITLE
tests: on_target: test for cloud configuration

### DIFF
--- a/tests/on_target/tests/test_functional/test_config.py
+++ b/tests/on_target/tests/test_functional/test_config.py
@@ -1,0 +1,55 @@
+##########################################################################################
+# Copyright (c) 2025 Nordic Semiconductor
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+##########################################################################################
+
+import os
+import pytest
+import time
+from utils.flash_tools import flash_device, reset_device
+import sys
+sys.path.append(os.getcwd())
+from utils.logger import get_logger
+
+logger = get_logger()
+
+CLOUD_TIMEOUT = 60 * 3
+DEFAULT_UPDATE_INTERVAL = 600
+TEST_UPDATE_INTERVAL = 150
+
+def test_config(dut_cloud, hex_file):
+    '''
+    Test that verifies shadow changes are applied c2d and d2c.
+    '''
+    flash_device(os.path.abspath(hex_file))
+    dut_cloud.uart.xfactoryreset()
+    dut_cloud.uart.flush()
+    reset_device()
+    dut_cloud.uart.wait_for_str("Connected to Cloud", timeout=120)
+
+    dut_cloud.cloud.patch_update_interval(dut_cloud.device_id, interval=TEST_UPDATE_INTERVAL)
+    dut_cloud.uart.wait_for_str(f"main: Received new interval: {TEST_UPDATE_INTERVAL} seconds", timeout=120)
+
+    # # Wait for shadow to be reported to cloud
+    start = time.time()
+    try:
+        while time.time() - start < CLOUD_TIMEOUT:
+                time.sleep(5)
+                try:
+                    device = dut_cloud.cloud.get_device(dut_cloud.device_id)
+                    device_state = device["state"]
+                    update_interval = device_state["reported"]["config"]["update_interval"]
+                except Exception as e:
+                    pytest.skip(f"Unable to retrieve device state from cloud, e: {e}")
+
+                logger.debug(f"Device state: {device_state}")
+                if update_interval == TEST_UPDATE_INTERVAL:
+                        break
+                else:
+                    logger.debug("No correct interval update reported yet, retrying...")
+                    continue
+        else:
+            raise RuntimeError(f"No correct update interval reported back to cloud, desired {TEST_UPDATE_INTERVAL}, reported {update_interval}")
+    finally:
+        # Back to default interval no matter what
+        dut_cloud.cloud.patch_update_interval(dut_cloud.device_id, interval=DEFAULT_UPDATE_INTERVAL)

--- a/tests/on_target/tests/test_functional/test_shell.py
+++ b/tests/on_target/tests/test_functional/test_shell.py
@@ -16,7 +16,7 @@ CLOUD_TIMEOUT = 60 * 3
 
 def test_shell(dut_cloud, hex_file):
     '''
-    Test that the device is operating normally by checking UART output
+    Test that the device is operating normally using shell commands
     '''
     flash_device(os.path.abspath(hex_file))
     dut_cloud.uart.xfactoryreset()

--- a/tests/on_target/utils/nrfcloud.py
+++ b/tests/on_target/utils/nrfcloud.py
@@ -120,6 +120,22 @@ class NRFCloud():
         diff = timedelta(hours=hours, minutes=minutes, seconds=seconds)
         return datetime.now(timezone.utc) - message[0].replace(tzinfo=timezone.utc) < diff
 
+    def patch_update_interval(self, device_id: str, interval: int) -> None:
+        """
+        Update the device's update interval configuration
+
+        :param device_id: Device ID to update
+        :param interval: New update interval in seconds
+        """
+        data = json.dumps({
+            "desired": {
+                "config": {
+                    "update_interval": interval
+                }
+            }
+        })
+        return self._patch(f"/devices/{device_id}/state", data=data)
+
 class NRFCloudFOTA(NRFCloud):
     def upload_firmware(
         self, name: str, bin_file: str, version: str, description: str, fw_type: FWType, bin_file_2=None


### PR DESCRIPTION
Add a test that verifies shadow changes are applied c2d and d2c.