### PR TITLE
Main fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,5 @@ The template is open-source for a reason, and we encourage users to contribute b
 - [Button](docs/modules/button.md)
 - [Cloud](docs/modules/cloud.md)
 - [Environmental](docs/modules/environmental.md)
-- [Main](docs/modules/main.md)
 - [Network](docs/modules/network.md)
 - [Power](docs/modules/power.md)

--- a/tests/module/main/src/main.c
+++ b/tests/module/main/src/main.c
@@ -262,11 +262,11 @@ void test_trigger_interval_change_in_connected(void)
 
 		send_location_search_done();
 		check_location_event(LOCATION_SEARCH_DONE);
+		check_network_event(NETWORK_QUALITY_SAMPLE_REQUEST);
+		check_power_event(POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST);
 	}
 
 	/* Cleanup */
-	purge_all_events();
-
 	send_cloud_disconnected();
 	check_no_events(WEEK_IN_SECONDS);
 }
@@ -310,8 +310,6 @@ void test_trigger_disconnect_and_connect_when_triggering(void)
 	}
 
 	/* Cleanup */
-	purge_all_events();
-
 	send_cloud_disconnected();
 	check_no_events(WEEK_IN_SECONDS);
 }


### PR DESCRIPTION
This pull request includes several changes to the `README.md` file and the `main.c` files in both the application and test modules. The most important changes include removing a module reference from the `README.md`, adding a new cloud message publication in the `sensor_and_poll_triggers_send` function, and modifying the `sample_data_entry` function to remove redundant cloud message publications.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50): Removed the reference to the `Main` module from the documentation list.

Code updates in `app/src/main.c`:

* [`sensor_and_poll_triggers_send`](diffhunk://#diff-18a06207913cad40c22ab9a9f6540cab69abbcdd85cd891a928b6b2aba7cb3c1R255-R264): Added a new cloud message publication to send a shadow trigger.
* [`sample_data_entry`](diffhunk://#diff-18a06207913cad40c22ab9a9f6540cab69abbcdd85cd891a928b6b2aba7cb3c1L481-L498): Removed redundant cloud message publication to simplify the function.

Test updates in `tests/module/main/src/main.c`:

* [`test_trigger_interval_change_in_connected`](diffhunk://#diff-024731dc6cdd96bd50de1c78c5a7f9cecced817eb45d04647aa935b0f8736d56R265-L269): Added checks for network quality and power battery percentage sample requests.
* [`test_trigger_disconnect_and_connect_when_triggering`](diffhunk://#diff-024731dc6cdd96bd50de1c78c5a7f9cecced817eb45d04647aa935b0f8736d56L313-L314): Removed redundant event purging to streamline the cleanup process.