### PR TITLE
Cloud docs and test fixes

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -398,9 +398,9 @@ static void idle_run(void *o)
 	struct main_state *state_object = o;
 
 	if (state_object->chan == &CLOUD_CHAN) {
-		struct cloud_msg msg = MSG_TO_CLOUD_MSG(state_object->msg_buf);
+		const struct cloud_msg *msg = MSG_TO_CLOUD_MSG_PTR(state_object->msg_buf);
 
-		if (msg.type == CLOUD_CONNECTED) {
+		if (msg->type == CLOUD_CONNECTED) {
 			state_object->connected = true;
 			smf_set_state(SMF_CTX(state_object), &states[STATE_TRIGGERING]);
 			return;
@@ -452,17 +452,17 @@ static void triggering_run(void *o)
 	struct main_state *state_object = o;
 
 	if (state_object->chan == &CLOUD_CHAN) {
-		struct cloud_msg msg = MSG_TO_CLOUD_MSG(state_object->msg_buf);
+		const struct cloud_msg *msg = MSG_TO_CLOUD_MSG_PTR(state_object->msg_buf);
 
-		if (msg.type == CLOUD_DISCONNECTED) {
+		if (msg->type == CLOUD_DISCONNECTED) {
 			state_object->connected = false;
 			smf_set_state(SMF_CTX(state_object), &states[STATE_IDLE]);
 			return;
 		}
 
-		if (msg.type == CLOUD_SHADOW_RESPONSE) {
-			err = get_update_interval_from_cbor_response(msg.response.buffer,
-								     msg.response.buffer_data_len,
+		if (msg->type == CLOUD_SHADOW_RESPONSE) {
+			err = get_update_interval_from_cbor_response(msg->response.buffer,
+								     msg->response.buffer_data_len,
 								     &state_object->interval_sec);
 			if (err) {
 				LOG_ERR("get_update_interval_from_cbor_response, error: %d", err);

--- a/app/src/modules/cloud/cloud_module.c
+++ b/app/src/modules/cloud/cloud_module.c
@@ -682,13 +682,7 @@ static void state_connected_ready_run(void *o)
 				SEND_FATAL_ERROR();
 				return;
 			}
-		}
-	}
-
-	if (state_object->chan == &CLOUD_CHAN) {
-		const enum cloud_msg_type msg_type = MSG_TO_CLOUD_MSG(state_object->msg_buf).type;
-
-		if (msg_type == CLOUD_POLL_SHADOW) {
+		} else if (msg.type == CLOUD_POLL_SHADOW) {
 			LOG_DBG("Poll shadow trigger received");
 
 			shadow_get(true);

--- a/app/src/modules/cloud/cloud_module.c
+++ b/app/src/modules/cloud/cloud_module.c
@@ -669,10 +669,10 @@ static void state_connected_ready_run(void *o)
 #endif /* CONFIG_APP_ENVIRONMENTAL */
 
 	if (state_object->chan == &CLOUD_CHAN) {
-		const struct cloud_msg msg = MSG_TO_CLOUD_MSG(state_object->msg_buf);
+		const struct cloud_msg *msg = MSG_TO_CLOUD_MSG_PTR(state_object->msg_buf);
 
-		if (msg.type == CLOUD_PAYLOAD_JSON) {
-			err = nrf_cloud_coap_json_message_send(msg.payload.buffer,
+		if (msg->type == CLOUD_PAYLOAD_JSON) {
+			err = nrf_cloud_coap_json_message_send(msg->payload.buffer,
 							       false, confirmable);
 			if (err == -ENETUNREACH) {
 				LOG_WRN("Network is unreachable, error: %d", err);
@@ -682,7 +682,7 @@ static void state_connected_ready_run(void *o)
 				SEND_FATAL_ERROR();
 				return;
 			}
-		} else if (msg.type == CLOUD_POLL_SHADOW) {
+		} else if (msg->type == CLOUD_POLL_SHADOW) {
 			LOG_DBG("Poll shadow trigger received");
 
 			shadow_get(true);

--- a/app/src/modules/cloud/cloud_module.c
+++ b/app/src/modules/cloud/cloud_module.c
@@ -127,28 +127,27 @@ static void state_connected_ready_run(void *o);
 static void state_connected_paused_entry(void *o);
 static void state_connected_paused_run(void *o);
 
-/* Defining the hierarchical cloud  module states:
- *
- *   STATE_RUNNING: The cloud  module has started and is running
- *      - STATE_DISCONNECTED: Cloud connection is not established
- *	- STATE_CONNECTING: The module is connecting to cloud
- *		- STATE_CONNECTING_ATTEMPT: The module is trying to connect to cloud
- *		- STATE_CONNECTING_BACKOFF: The module is waiting before trying to connect again
- *	- STATE_CONNECTED: Cloud connection has been established. Note that because of
- *			    connection ID being used, the connection is valid even though
- *			    network connection is intermittently lost (and socket is closed)
- *		- STATE_CONNECTED_READY: Connected to cloud and network connection, ready to send
- *		- STATE_CONNECTED_PAUSED: Connected to cloud, but not network connection
- */
+/* Defining the hierarchical cloud  module states: */
 enum cloud_module_state {
+	/* The cloud module has started and is running */
 	STATE_RUNNING,
-	STATE_DISCONNECTED,
-	STATE_CONNECTING,
-	STATE_CONNECTING_ATTEMPT,
-	STATE_CONNECTING_BACKOFF,
-	STATE_CONNECTED,
-	STATE_CONNECTED_READY,
-	STATE_CONNECTED_PAUSED,
+		/* Cloud connection is not established */
+		STATE_DISCONNECTED,
+		/* The module is connecting to cloud */
+		STATE_CONNECTING,
+			/* The module is trying to connect to cloud */
+			STATE_CONNECTING_ATTEMPT,
+			/* The module is waiting before trying to connect again */
+			STATE_CONNECTING_BACKOFF,
+		/* Cloud connection has been established. Note that because of
+		 * connection ID being used, the connection is valid even though
+		 * network connection is intermittently lost (and socket is closed)
+		 */
+		STATE_CONNECTED,
+			/* Connected to cloud and network connection, ready to send data */
+			STATE_CONNECTED_READY,
+			/* Connected to cloud, but not network connection */
+			STATE_CONNECTED_PAUSED,
 };
 
 /* Construct state table */
@@ -163,21 +162,21 @@ static const struct smf_state states[] = {
 				 &states[STATE_RUNNING],
 				 NULL),
 
-	[STATE_CONNECTING] = SMF_CREATE_STATE(
-				state_connecting_entry, NULL, NULL,
-				&states[STATE_RUNNING],
-				&states[STATE_CONNECTING_ATTEMPT]),
+	[STATE_CONNECTING] =
+		SMF_CREATE_STATE(state_connecting_entry, NULL, NULL,
+				 &states[STATE_RUNNING],
+				 &states[STATE_CONNECTING_ATTEMPT]),
 
-	[STATE_CONNECTING_ATTEMPT] = SMF_CREATE_STATE(
-				state_connecting_attempt_entry, NULL, NULL,
-				&states[STATE_CONNECTING],
-				NULL),
+	[STATE_CONNECTING_ATTEMPT] =
+		SMF_CREATE_STATE(state_connecting_attempt_entry, NULL, NULL,
+				 &states[STATE_CONNECTING],
+				 NULL),
 
-	[STATE_CONNECTING_BACKOFF] = SMF_CREATE_STATE(
-				state_connecting_backoff_entry, state_connecting_backoff_run,
-				state_connecting_backoff_exit,
-				&states[STATE_CONNECTING],
-				NULL),
+	[STATE_CONNECTING_BACKOFF] =
+		SMF_CREATE_STATE(state_connecting_backoff_entry, state_connecting_backoff_run,
+				 state_connecting_backoff_exit,
+				 &states[STATE_CONNECTING],
+				 NULL),
 
 	[STATE_CONNECTED] =
 		SMF_CREATE_STATE(state_connected_entry, NULL, state_connected_exit,
@@ -327,7 +326,7 @@ static void state_running_run(void *o)
 	}
 }
 
-/* Handlers for STATE_CLOUD_DISCONNECTED. */
+/* Handlers for STATE_DISCONNECTED. */
 static void state_disconnected_entry(void *o)
 {
 	int err;
@@ -427,7 +426,7 @@ static void state_connecting_backoff_exit(void *o)
 	(void)k_work_cancel_delayable(&backoff_timer_work);
 }
 
-/* Handler for STATE_CLOUD_CONNECTED. */
+/* Handler for STATE_CONNECTED. */
 static void state_connected_entry(void *o)
 {
 	ARG_UNUSED(o);

--- a/app/src/modules/cloud/cloud_module.h
+++ b/app/src/modules/cloud/cloud_module.h
@@ -42,8 +42,10 @@ enum cloud_msg_type {
 
 struct cloud_msg {
 	enum cloud_msg_type type;
-	struct cloud_payload payload;
-	struct cloud_shadow_response response;
+	union  {
+		struct cloud_payload payload;
+		struct cloud_shadow_response response;
+	};
 };
 
 #define MSG_TO_CLOUD_MSG(_msg)	(*(const struct cloud_msg *)_msg)

--- a/app/src/modules/cloud/cloud_module.h
+++ b/app/src/modules/cloud/cloud_module.h
@@ -48,7 +48,8 @@ struct cloud_msg {
 	};
 };
 
-#define MSG_TO_CLOUD_MSG(_msg)	(*(const struct cloud_msg *)_msg)
+/* Cast a pointer to a message to a pointer to a cloud message */
+#define MSG_TO_CLOUD_MSG_PTR(_msg)	((const struct cloud_msg *)_msg)
 
 #ifdef __cplusplus
 }

--- a/docs/modules/cloud.md
+++ b/docs/modules/cloud.md
@@ -1,11 +1,133 @@
 # Cloud module
 
-What does this module do
+This module connects and manages communication with [nRF Cloud](https://www.nrfcloud.com/) over CoAP using [nRF Cloud CoAP library](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/networking/nrf_cloud_coap.html) in nRF Connect SDK. It controls the cloud connection, sends data to nRF Cloud, and processes incoming data such as device shadow document. The cloud module uses Zephyr’s state machine framework (SMF) and zbus for messaging with other modules.
+
+The module's responsibilities include:
+
+- Establishing and maintaining a connection to nRF Cloud, using CoAP with DTLS connection ID for secure and low-power communication.
+- Managing backoff and retries when connecting to the cloud. See the [Configurations](#configurations) section for more details on how to configure backoff behavior.
+- Publishing sensor data (temperature, pressure, connection quality, etc.) to nRF Cloud. The data is received on the `ENVIRONMENTAL_CHAN` channel when the environmental module publishes it.
+- Requesting and handling shadow updates. Polling the device shadow is triggered by the main module by sending a `CLOUD_POLL_SHADOW` message.
+- Handling network events and transitioning between connection states as described in the [State diagram](#state-diagram) section.
+
+nRF Cloud over CoAP utilizes DTLS connection ID which allows the device to quickly re-establish a secure connection with the cloud after a network disconnection without the need for a full DTLS handshake. The module uses the nRF Cloud CoAP library to handle the CoAP communication and DTLS connection management.
+
+Below, the module’s main messages, configurations, and state machine are covered. Refer to the source files (`cloud_module.c`, `cloud_module.h`, and `Kconfig.cloud`) for implementation details.
 
 ## Messages
 
+The cloud module publishes and receives messages over the zbus channel `CLOUD_CHAN`. All module message types are defined in `cloud_module.h` and used within `cloud_module.c`.
+
+### Input Messages
+
+- **CLOUD_POLL_SHADOW**
+  Instructs the module to poll the device shadow on nRF Cloud. The device shadow may contain configuration updates for the device.
+
+- **CLOUD_PAYLOAD_JSON**
+  Sends raw JSON data to nRF Cloud.
+
+### Output Messages
+
+- **CLOUD_DISCONNECTED**
+  Indicates that the cloud connection is not established (or has been lost).
+
+- **CLOUD_CONNECTED**
+  Indicates that the module is connected to nRF Cloud and ready to send data.
+
+- **CLOUD_SHADOW_RESPONSE**
+  Returns shadow data or a shadow delta received from nRF Cloud.
+
+The message structure used by the cloud module is defined in `cloud_module.h`:
+
+```c
+struct cloud_msg {
+	enum cloud_msg_type type;
+	union  {
+		struct cloud_payload payload;
+		struct cloud_shadow_response response;
+	};
+};
+```
+
 ## Configurations
 
-Kconfig and device tree
+Several Kconfig options in `Kconfig.cloud` control this module’s behavior. Below are some notable ones:
+
+- **CONFIG_APP_CLOUD_SHELL**
+  Enables shell support for cloud operations.
+
+- **CONFIG_APP_CLOUD_PAYLOAD_BUFFER_MAX_SIZE**
+  Defines the maximum size for JSON payloads sent to the cloud.
+
+- **CONFIG_APP_CLOUD_SHADOW_RESPONSE_BUFFER_MAX_SIZE**
+  Sets the maximum buffer size for receiving shadow data.
+
+- **CONFIG_APP_CLOUD_CONFIRMABLE_MESSAGES**
+  Uses confirmable CoAP messages for reliability.
+
+- **CONFIG_APP_CLOUD_BACKOFF_INITIAL_SECONDS**
+  Starting delay (in seconds) before reconnect attempts.
+
+- **CONFIG_APP_CLOUD_BACKOFF_TYPE**
+  Specifies backoff strategy (none, linear, or exponential).
+
+- **CONFIG_APP_CLOUD_BACKOFF_TYPE_EXPONENTIAL**
+  Use exponential backoff time. The backoff time is doubled after each failed attempt until the
+  maximum backoff time is reached.
+
+- **CONFIG_APP_CLOUD_BACKOFF_TYPE_LINEAR**
+  Use linear backoff time. The backoff time is incremented by a fixed amount after each failed attempt until
+  the maximum backoff time is reached.
+
+- **CONFIG_APP_CLOUD_BACKOFF_LINEAR_INCREMENT_SECONDS**
+  If using linear backoff, defines how much time to add after each failed attempt.
+
+- **CONFIG_APP_CLOUD_BACKOFF_MAX_SECONDS**
+  Maximum reconnect backoff limit.
+
+- **CONFIG_APP_CLOUD_THREAD_STACK_SIZE**
+  Stack size for the cloud module’s main thread.
+
+- **CONFIG_APP_CLOUD_MESSAGE_QUEUE_SIZE**
+  Zbus message queue size.
+
+- **CONFIG_APP_CLOUD_WATCHDOG_TIMEOUT_SECONDS**
+  Watchdog timeout for the module’s thread. Must be larger than the message processing timeout.
+
+- **CONFIG_APP_CLOUD_MSG_PROCESSING_TIMEOUT_SECONDS**
+  Maximum time allowed for processing a single incoming message.
+
+For more details on these and other configurations, refer to `Kconfig.cloud`.
 
 ## State diagram
+
+Below is a simplified representation of the state machine implemented in `cloud_module.c`. The module starts in the **STATE_RUNNING** context, which immediately transitions to **STATE_DISCONNECTED** upon initialization. From there, network events and internal conditions drive state transitions.
+
+```mermaid
+stateDiagram-v2
+    [*] --> STATE_RUNNING
+
+    STATE_RUNNING --> STATE_DISCONNECTED: NETWORK_DISCONNECTED
+
+    state STATE_RUNNING {
+        [*] --> STATE_DISCONNECTED
+
+        STATE_DISCONNECTED --> STATE_CONNECTING: NETWORK_CONNECTED
+
+        STATE_CONNECTING --> STATE_CONNECTED: CLOUD_CONN_SUCCESS
+
+        state STATE_CONNECTING {
+            [*] --> STATE_CONNECTING_ATTEMPT
+
+            STATE_CONNECTING_ATTEMPT --> STATE_CONNECTING_BACKOFF: CLOUD_CONN_FAILED
+            STATE_CONNECTING_BACKOFF --> STATE_CONNECTING_ATTEMPT: CLOUD_BACKOFF_EXPIRED
+        }
+
+        state STATE_CONNECTED {
+            [*] --> STATE_CONNECTED_READY_TO_SEND
+
+            STATE_CONNECTED_READY_TO_SEND --> STATE_CONNECTED_PAUSED: NETWORK_DISCONNECTED
+            STATE_CONNECTED_PAUSED --> STATE_CONNECTED_READY_TO_SEND: NETWORK_CONNECTED
+        }
+    }
+```

--- a/tests/module/main/src/main.c
+++ b/tests/module/main/src/main.c
@@ -123,10 +123,10 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 	}
 }
 
-static void send_cloud_connected_ready_to_send(void)
+static void send_cloud_connected(void)
 {
 	struct cloud_msg cloud_msg = {
-		.type = CLOUD_CONNECTED_READY_TO_SEND,
+		.type = CLOUD_CONNECTED,
 	};
 
 	int err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
@@ -202,7 +202,7 @@ static void send_network_disconnected(void)
 void test_init_to_triggering_state(void)
 {
 	/* Transition the module into STATE_TRIGGERING */
-	send_cloud_connected_ready_to_send();
+	send_cloud_connected();
 
 	/* There's an initial transition to STATE_SAMPLE_DATA, where the entry function
 	 * sends a location search trigger.
@@ -226,7 +226,7 @@ void test_init_to_triggering_state(void)
 void test_button_press_on_connected(void)
 {
 	/* Transition to STATE_SAMPLE_DATA */
-	send_cloud_connected_ready_to_send();
+	send_cloud_connected();
 	expect_location_event(LOCATION_SEARCH_TRIGGER);
 
 	/* Transistion to STATE_WAIT_FOR_TRIGGER */
@@ -263,7 +263,7 @@ void test_button_press_on_disconnected(void)
 void test_trigger_interval_change_in_connected(void)
 {
 	/* Transition to STATE_SAMPLE_DATA */
-	send_cloud_connected_ready_to_send();
+	send_cloud_connected();
 	expect_location_event(LOCATION_SEARCH_TRIGGER);
 
 	/* As response to the shadow poll, the interval is set to 12 hours. */
@@ -303,7 +303,7 @@ void test_trigger_disconnect_and_connect_when_triggering(void)
 	bool first_trigger_after_connect = true;
 
 	/* Transition to STATE_SAMPLE_DATA */
-	send_cloud_connected_ready_to_send();
+	send_cloud_connected();
 
 	/* As response to the shadow poll, the interval is set to 12 hours. */
 	twelve_hour_interval_set();
@@ -331,7 +331,7 @@ void test_trigger_disconnect_and_connect_when_triggering(void)
 		if (i % 2 == 0) {
 			send_cloud_disconnected();
 			expect_no_events(7200);
-			send_cloud_connected_ready_to_send();
+			send_cloud_connected();
 
 			first_trigger_after_connect = true;
 		}
@@ -349,7 +349,7 @@ void test_fota_downloading(void)
 	expect_fota_event(FOTA_DOWNLOADING_UPDATE);
 
 	/* A cloud ready message and button trigger should now cause no action */
-	send_cloud_connected_ready_to_send();
+	send_cloud_connected();
 	expect_no_events(7200);
 	button_handler(DK_BTN1_MSK, DK_BTN1_MSK);
 	expect_no_events(7200);


### PR DESCRIPTION
This pull request includes several changes to the cloud module and its associated documentation and tests. The most important changes include restructuring the state definitions, updating the documentation to provide more details on the module's functionality, and modifying test cases to reflect the changes in state handling.

### Restructuring state definitions:
* Refactored the hierarchical cloud module states for better readability and maintainability in `cloud_module.c`.
* Updated state handler comments to reflect the new state names. [[1]](diffhunk://#diff-19c5d76147d9c5e2277505a42dbff2d2fb8b5babb9b21b540ffa61db038fc1f5L330-R329) [[2]](diffhunk://#diff-19c5d76147d9c5e2277505a42dbff2d2fb8b5babb9b21b540ffa61db038fc1f5L430-R429)

### Documentation updates:
* Enhanced the `docs/modules/cloud.md` with detailed descriptions of the module's responsibilities, messages, configurations, and state machine.

### Test case modifications:
* Consolidated semaphore definitions and updated test cases to align with the new state names in `cloud_module_test.c`. [[1]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL83-R83) [[2]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL108-R108) [[3]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL165-R162) [[4]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL185-R182) [[5]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL211-R208) [[6]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL221-R228) [[7]](diffhunk://#diff-72ebdc9f1971c93907aff34da708f942f93d1aff702303649b1ff20e612b349aL244-R241)

### Code improvements:
* Simplified the `state_connected_ready_run` function by removing redundant checks and improving readability in `cloud_module.c`.
* Added a union to the `cloud_msg` structure to encapsulate payload and shadow response in `cloud_module.h`.