### PR TITLE
Add documentation for power, LED and environmental modules

### DIFF
--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -9,7 +9,6 @@
 #include <zephyr/zbus/zbus.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/task_wdt/task_wdt.h>
-#include <drivers/bme68x_iaq.h>
 #include <date_time.h>
 #include <zephyr/smf.h>
 

--- a/app/src/modules/led/led.c
+++ b/app/src/modules/led/led.c
@@ -102,7 +102,6 @@ static int pwm_out(const struct led_msg *led_msg, bool force_off)
 	return 0;
 }
 
-
 /* Timer work handler for LED blinking */
 static void blink_timer_handler(struct k_work *work)
 {

--- a/docs/modules/button.md
+++ b/docs/modules/button.md
@@ -4,6 +4,8 @@ The button module provides button press event handling functionality for the app
 
 ## Messages
 
+The button module communicates via the zbus channel `BUTTON_CHAN`.
+
 ### Output Messages
 
-- **BUTTON_CHAN**: The module publishes button events through the `BUTTON_CHAN`.
+- The module publishes a message with payload of type `uint8_t` with the button number that has been pressed.

--- a/docs/modules/environmental.md
+++ b/docs/modules/environmental.md
@@ -1,11 +1,64 @@
 # Environmental module
 
-What does this module do
+The Environmental module collects sensor data from the onboard BME680 environmental sensor on the Thingy:91 X.
+The module provides temperature, pressure, and humidity readings to other modules through the zbus messaging system. The module initializes the sensor hardware and responds to sampling requests from the main application module.
+
+To initiate a sensor reading, the main module sends an `ENVIRONMENTAL_SENSOR_SAMPLE_REQUEST` message to the environmental module. The environmental module then reads the sensor data and sends an `ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE` message with the collected data asynchronously.
 
 ## Messages
 
+The Environmental module communicates via the zbus channel `ENVIRONMENTAL_CHAN`, using message types defined in `environmental.h`.
+
+### Input Messages
+
+- **ENVIRONMENTAL_SENSOR_SAMPLE_REQUEST**
+  Requests the module to take new sensor readings from the environmental sensor.
+
+### Output Messages
+
+- **ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE**
+  Returns collected environmental data with the following fields:
+  - `temperature`: Temperature value in degrees Celsius
+  - `pressure`: Atmospheric pressure in Pascals
+  - `humidity`: Relative humidity percentage
+
+The message structure used by the environmental module is defined in `environmental.h`:
+
+```c
+struct environmental_msg {
+    enum environmental_msg_type type;
+    double temperature;
+    double pressure;
+    double humidity;
+};
+```
+
 ## Configurations
 
-Kconfig and device tree
+The Environmental module can be configured using the following Kconfig options:
+
+- **CONFIG_APP_ENVIRONMENTAL**
+  Enables the Environmental module.
+
+- **CONFIG_APP_ENVIRONMENTAL_THREAD_STACK_SIZE**
+  Size of the stack for the environmental module's thread.
+
+- **CONFIG_APP_ENVIRONMENTAL_WATCHDOG_TIMEOUT_SECONDS**
+  Defines the watchdog timeout for the environmental module.
+
+- **CONFIG_APP_ENVIRONMENTAL_MSG_PROCESSING_TIMEOUT_SECONDS**
+  Maximum time allowed for processing a single message.
+
+- **CONFIG_APP_ENVIRONMENTAL_LOG_LEVEL_INF/_ERR/_WRN/_DBG**
+  Controls logging level for the environmental module.
+
+For more details on Kconfig options, see the `Kconfig.environmental` file in the module's directory.
 
 ## State diagram
+
+The environmental module implements a very simple state machine with only one state:
+
+```mermaid
+stateDiagram-v2
+    [*] --> STATE_RUNNING
+```

--- a/docs/modules/led.md
+++ b/docs/modules/led.md
@@ -1,11 +1,70 @@
-# LED module
+# LED Module
 
-What does this module do
+The LED module controls the LEDs on the device using PWM (Pulse Width Modulation) and timers to created blinking patterns. For devices with RGB LEDs, the module can set specific colors. For devices without RGB LEDs, the colors will map to regular LEDs instead.
 
 ## Messages
 
+The LED module uses the zbus channel `LED_CHAN` to receive control commands. Other modules can publish messages to this channel to control the LED behavior.
+
+The module accepts messages with the following parameters:
+
+- **Color Values**
+  - `red`: Red component (0-255)
+  - `green`: Green component (0-255)
+  - `blue`: Blue component (0-255)
+
+- **Timing Parameters**
+  - `duration_on_msec`: How long the LED stays on in milliseconds
+  - `duration_off_msec`: How long the LED stays off in milliseconds
+  - `repetitions`: Number of blink cycles (-1 for infinite blinking)
+
+The message structure is defined in `led_module.h`:
+
+```c
+struct led_msg {
+    enum led_msg_type type;
+
+	/** RGB values (0 to 255) */
+	uint8_t red;
+	uint8_t green;
+	uint8_t blue;
+
+	/** Duration of the RGB on/off cycle */
+	uint32_t duration_on_msec;
+	uint32_t duration_off_msec;
+
+	/** Number of on/off cycles (-1 indicates forever) */
+	int repetitions;
+};
+```
+
+## Operation
+
+Instead of using a state machine, the LED module operates as follows:
+
+1. When a message is received on the `LED_CHAN` channel:
+   - Any existing blink pattern is canceled
+   - The new LED state (colors and timing) is saved
+   - The LED is turned on with the specified color
+
+2. If a blinking pattern is specified (repetitions != 0):
+   - A timer is started with `duration_on_msec`
+   - When the timer expires, the LED toggles between on and off states
+   - The timer alternates between `duration_on_msec` and `duration_off_msec`
+   - This continues until the specified number of repetitions is reached
+   - If repetitions is -1, the blinking continues indefinitely or until a new message is received
+
+The module handles error cases gracefully and reports issues through logging.
+
 ## Configurations
 
-Kconfig and device tree
+The LED module uses the following configuration options:
 
-## State diagram
+- **CONFIG_APP_LED_LOG_LEVEL**
+  Controls logging level for the LED module.
+
+- **Device Tree Configuration**
+  The module requires three PWM LED aliases in the device tree:
+  - `pwm-led0`: Red channel
+  - `pwm-led1`: Green channel
+  - `pwm-led2`: Blue channel

--- a/docs/modules/power.md
+++ b/docs/modules/power.md
@@ -1,11 +1,65 @@
 # Power module
 
-What does this module do
+The power module manages power-related functionality for devices with nPM1300, like the Thingy:91 X, including the following:
+- Monitoring battery voltage and calculating remaining battery percentage.
+- Handling VBUS (USB) connect and disconnect events to enable or disable UART peripherals.
+- Publishing battery percentage updates via zbus messages.
 
 ## Messages
 
+The Power module defines and communicates on the `POWER_CHAN` channel.
+
+### Input Messages
+
+- **POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST**
+  Requests a battery percentage sample.
+
+### Output Messages
+
+- **POWER_BATTERY_PERCENTAGE_SAMPLE_RESPONSE**
+  Contains the calculated battery percentage.
+
+The power message structure is defined in `power.h`:
+
+```c
+struct power_msg {
+	enum power_msg_type type;
+
+	/** Contains the current charge of the battery in percentage. */
+	double percentage;
+};
+```
+
 ## Configurations
 
-Kconfig and device tree
+The following Kconfig options control this module’s behavior:
+
+- **CONFIG_APP_POWER**
+  Enables the Power module.
+
+- **CONFIG_APP_POWER_DISABLE_UART_ON_VBUS_REMOVED**
+  If enabled, suspends UART devices when VBUS is removed.
+
+- **CONFIG_APP_POWER_THREAD_STACK_SIZE**
+  Size of the Power module’s thread stack.
+
+- **CONFIG_APP_POWER_WATCHDOG_TIMEOUT_SECONDS**
+  Defines the watchdog timeout for the module. Must be larger than the message processing timeout.
+
+- **CONFIG_APP_POWER_MSG_PROCESSING_TIMEOUT_SECONDS**
+  Maximum time spent processing a single message.
+
+See the `Kconfig.power` file in the module's directory for more details on the available Kconfig options.
+
+## Kconfig and device tree
+
+- The Power module uses `npm1300_charger` as specified by device tree.
+- The two UART devices `uart0_dev` and `uart1_dev` defined in device tree will be enabled or disabled based on VBUS events.
 
 ## State diagram
+
+The Power module uses a minimal state machine with a single state, **STATE_RUNNING**. In this state, the module:
+1. Initializes the charger and optional fuel gauge in the state entry function.
+2. Waits for messages to arrive via zbus.
+3. Handles battery sample requests and publishes results.
+4. Monitors for VBUS events to enable or disable UART devices.


### PR DESCRIPTION
This pull request includes several documentation updates and code changes across multiple modules to improve clarity and functionality. The most important changes include detailed explanations of module functionalities, message structures, and configuration options.

Documentation updates:

* [`docs/modules/environmental.md`](diffhunk://#diff-2b06183af9622c332a1427942ef0ec03e889d45e20dca6ff7d3401901f8e0df6L3-R64): Expanded the description of the Environmental module, including how it collects and communicates sensor data, message types, and configuration options.
* [`docs/modules/led.md`](diffhunk://#diff-4c9be35dd278b139c02b6d04ef5e2cf962041c2a5ac116d2e26001175fdec74cL1-R70): Enhanced the LED module documentation with details on message parameters, operation, and configuration options.
* [`docs/modules/power.md`](diffhunk://#diff-56b68fbe82216951760012aa5619c5b1feae53356c074206388e0afd8d62a25bL3-R65): Updated the Power module documentation to include functionality, message types, and configuration options.

Code changes:

* [`app/src/modules/environmental/environmental.c`](diffhunk://#diff-b8548bc299f7a53c22be318147f7ce307ce55b9567244cf82ab0fe76c7881293L12): Removed unused `bme68x_iaq.h` header file.
* [`app/src/modules/led/led.c`](diffhunk://#diff-9e5861119b27d143da1c08baf26a943e0d9799fcb55db8db9d89efa57cedade1L105): Removed an unnecessary blank line in the `pwm_out` function.

These changes enhance the clarity and maintainability of the documentation and codebase.