### PR TITLE
modules: Use X macros to subscribe to channels

### DIFF
--- a/app/src/common/app_common.h
+++ b/app/src/common/app_common.h
@@ -56,9 +56,35 @@ extern "C" {
 
 /**
  * @brief Macro to compute the maximum of a list of numbers.
+ *
  * @param ... List of numbers to compute the maximum of.
  */
-#define MAX_N(...) SELECT_MAX_N(NUM_VA_ARGS(__VA_ARGS__))(__VA_ARGS__)
+#define MAX_N(...)			SELECT_MAX_N(NUM_VA_ARGS(__VA_ARGS__))(__VA_ARGS__)
+
+/**
+ * @brief Helper macro for computing the size of a type.
+ * The intended use is with X macros to generate a list of sizes for each type in a list of types.
+ *
+ * @param _chan Channel to compute the size of the type for.
+ * @param _type Type to compute the size of.
+ *
+ * @return Size of the type.
+ */
+#define SIZE_OF_TYPE(_chan, _type)	sizeof(_type),
+
+/**
+ * @brief Macro to compute the maximum message size from a list of channel date types.
+ *	  The macro expands to a list of sizeof(type) for each channel's type, followed by a 0 to
+ *	  account for the trailing comma when expanding SIZE_OF_TYPE
+ *	  The MAX_N macro is used to find the maximum value in the list.
+ *	  Example: MAX_N(sizeof(struct cloud_msg), sizeof(enum fota_msg_type), 0)
+
+ * @param _CHAN_LIST List of channels to compute the maximum message size from.
+ *		     The list should be in the format: (CHANNEL_NAME, type)
+ *
+ * @return Maximum message size from the list of channels
+ */
+#define MAX_MSG_SIZE_FROM_LIST(_CHAN_LIST)	MAX_N(_CHAN_LIST(SIZE_OF_TYPE) 0)
 
 #ifdef __cplusplus
 }

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -33,6 +33,7 @@
 
 /* Register log module */
 LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);
+
 /* Register subscriber */
 ZBUS_MSG_SUBSCRIBER_DEFINE(main_subscriber);
 
@@ -56,21 +57,17 @@ ZBUS_CHAN_DEFINE(TIMER_CHAN,
 	X(LOCATION_CHAN,	enum location_msg_type)		\
 	X(TIMER_CHAN,		int)
 
-/* Calculate the maximum message size from the list of channels
- * The macro expands to a list of sizeof(type) for each channel's type, followed by a 0 to account
- * for the trailing comma when expanding SIZE_OF_TYPE
- * The MAX_N macro is used to find the maximum value in the list.
- * Example: MAX_N(sizeof(struct cloud_msg), sizeof(enum fota_msg_type), 0)
- */
-#define SIZE_OF_TYPE(chan, type)		sizeof(type),
-#define MAX_MSG_SIZE				MAX_N(CHANNEL_LIST(SIZE_OF_TYPE) 0)
+/* Calculate the maximum message size from the list of channels */
+#define MAX_MSG_SIZE				MAX_MSG_SIZE_FROM_LIST(CHANNEL_LIST)
 
-/* Add main_subscriber as observer to all the channels in the list.
- * This expands to a call to ZBUS_CHAN_ADD_OBS for each channel in the list.
+/* Add main_subscriber as observer to all the channels in the list. */
+#define ADD_OBSERVERS(_chan, _type)		ZBUS_CHAN_ADD_OBS(_chan, main_subscriber, 0);
+
+/*
+ * Expand to a call to ZBUS_CHAN_ADD_OBS for each channel in the list.
  * Example: ZBUS_CHAN_ADD_OBS(CLOUD_CHAN, main_subscriber, 0);
  */
-#define ADD_OBSERVERS(_chan, _type)		ZBUS_CHAN_ADD_OBS(_chan, main_subscriber, 0);
-	CHANNEL_LIST(ADD_OBSERVERS)
+CHANNEL_LIST(ADD_OBSERVERS)
 
 /* Forward declarations */
 static void timer_work_fn(struct k_work *work);


### PR DESCRIPTION
This pull request includes several updates to macros and subscriber definitions to improve code maintainability and readability. The most important changes involve the introduction of new macros for computing message sizes and updating subscriber definitions across multiple files.

### Macro improvements:
* Added `SIZE_OF_TYPE` and `MAX_MSG_SIZE_FROM_LIST` macros to compute the maximum message size from a list of channel data types in `app/src/common/app_common.h`.
* Updated `MAX_MSG_SIZE` macro in `app/src/main.c` to use `MAX_MSG_SIZE_FROM_LIST` for calculating the maximum message size from the list of channels.

### Subscriber updates:
* Renamed `cloud` subscriber to `cloud_subscriber` and updated all references in `app/src/modules/cloud/cloud_module.c`. [[1]](diffhunk://#diff-19c5d76147d9c5e2277505a42dbff2d2fb8b5babb9b21b540ffa61db038fc1f5L36-R64) [[2]](diffhunk://#diff-19c5d76147d9c5e2277505a42dbff2d2fb8b5babb9b21b540ffa61db038fc1f5L95-R88) [[3]](diffhunk://#diff-19c5d76147d9c5e2277505a42dbff2d2fb8b5babb9b21b540ffa61db038fc1f5L755-R748)
* Defined `CHANNEL_LIST` macro and used it to add observers for all channels in `app/src/modules/cloud/cloud_module.c`.

### Miscellaneous:
* Added a blank line after `LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL);` in `app/src/main.c` for better readability.