### PR TITLE
workflows: target-test: small fixes

### DIFF
--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -59,7 +59,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             matrix="${{ github.event.inputs.devices }}"
           elif [[ "${{ inputs.is_scheduled }}" == "true" ]]; then
-              matrix='["thingy91x","nrf9151dk"]'
+              matrix='["thingy91x","nrf9151dk","ppk_thingy91x"]'
           else
             matrix='["thingy91x"]'
           fi
@@ -138,6 +138,14 @@ jobs:
               --check-uploaded \
               asset-tracker-template-${{ inputs.artifact_fw_version }}-${{ vars.DUT_DEVICE_TYPE }}-nrf91.elf
 
+      - name: Generate and Push RAM and FLASH Badges
+        if: ${{ matrix.device == 'thingy91x' && inputs.is_scheduled }}
+        continue-on-error: true
+        working-directory: asset-tracker-template
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./tests/on_target/scripts/update_memory_badges.sh tests/on_target/artifacts/build_output_thingy91x.log
+
       - name: Target Tests
         working-directory: asset-tracker-template/tests/on_target
         run: |
@@ -183,14 +191,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./tests/on_target/scripts/update_power_badge.sh
-
-      - name: Generate and Push RAM and FLASH Badges
-        if: ${{ matrix.device == 'thingy91x' && inputs.is_scheduled }}
-        continue-on-error: true
-        working-directory: asset-tracker-template
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./tests/on_target/scripts/update_memory_badges.sh tests/on_target/artifacts/build_output_thingy91x.log
 
       - name: Results
         if: always()


### PR DESCRIPTION
Add missing ppk_thingy91x device.
Move memory badges gen before test step.
Otherwise it does not get executed on failure.