### PR TITLE
workflows: fix MEMFAULT_CDR_MAX_ENCODED_METADATA_LEN error

### DIFF
--- a/.github/actions/build-step/action.yml
+++ b/.github/actions/build-step/action.yml
@@ -8,7 +8,7 @@ inputs:
   memfault_fw_type:
     type: string
     required: false
-    default: "asset-tracker-template-dev"
+    default: "att-dev"
   memfault_fw_version_prefix:
     type: string
     required: false

--- a/.github/workflows/attach_release_assets.yml
+++ b/.github/workflows/attach_release_assets.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     secrets: inherit
     with:
-      memfault_fw_type: "asset-tracker-template"
+      memfault_fw_type: "att"
 
   attach-assets:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,13 @@ on:
       memfault_fw_type:
         type: string
         required: false
-        default: "asset-tracker-template-dev"
+        default: "att-dev"
   workflow_call:
     inputs:
       memfault_fw_type:
         type: string
         required: false
-        default: "asset-tracker-template-dev"
+        default: "att-dev"
       nrfsdk_sha_update:
         type: boolean
         required: false
@@ -101,7 +101,7 @@ jobs:
         shell: bash
         run: |
           if [[ -z "${{ inputs.memfault_fw_type }}" ]]; then
-            echo "MEMFAULT_FW_TYPE=asset-tracker-template-dev" >> $GITHUB_ENV
+            echo "MEMFAULT_FW_TYPE=att-dev" >> $GITHUB_ENV
           else
             echo "MEMFAULT_FW_TYPE=${{ inputs.memfault_fw_type }}" >> $GITHUB_ENV
           fi
@@ -116,9 +116,6 @@ jobs:
       - name: Build thingy91x firmware
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
-          memfault_project_key: ${{ secrets.MEMFAULT_PROJECT_KEY }}
-          memfault_fw_type: ${{ env.MEMFAULT_FW_TYPE }}
-          memfault_fw_version_prefix: ${{ env.MEMFAULT_FW_VERSION_PREFIX }}
           board: thingy91x/nrf9151/ns
           short_board: thingy91x
           version: ${{ env.VERSION }}
@@ -128,9 +125,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
-          memfault_project_key: ${{ secrets.MEMFAULT_PROJECT_KEY }}
-          memfault_fw_type: ${{ env.MEMFAULT_FW_TYPE }}
-          memfault_fw_version_prefix: ${{ env.MEMFAULT_FW_VERSION_PREFIX }}
           board: nrf9151dk/nrf9151/ns
           short_board: nrf9151dk
           version: ${{ env.VERSION }}
@@ -143,7 +137,7 @@ jobs:
         with:
           memfault_project_key: ${{ secrets.MEMFAULT_PROJECT_KEY }}
           memfault_fw_type: ${{ env.MEMFAULT_FW_TYPE }}
-          memfault_fw_version_prefix: ${{ env.MEMFAULT_FW_VERSION_PREFIX }}-debug
+          memfault_fw_version_prefix: ${{ env.MEMFAULT_FW_VERSION_PREFIX }}
           board: thingy91x/nrf9151/ns
           short_board: thingy91x
           version: ${{ env.VERSION }}-debug

--- a/tests/on_target/tests/conftest.py
+++ b/tests/on_target/tests/conftest.py
@@ -142,6 +142,10 @@ def hex_file():
 
 @pytest.fixture(scope="session")
 def debug_hex_file():
+    # Skip if not thingy91x since debug build is only available for thingy91x
+    if DUT_DEVICE_TYPE != 'thingy91x':
+        pytest.skip("Debug build is only available for thingy91x")
+
     # Search for the debug firmware hex file in the artifacts folder
     artifacts_dir = "artifacts/"
     hex_pattern = f"asset-tracker-template-{r'[0-9a-z\.]+'}-debug-{DUT_DEVICE_TYPE}-nrf91.hex"

--- a/tests/on_target/tests/test_functional/test_memfault.py
+++ b/tests/on_target/tests/test_functional/test_memfault.py
@@ -90,9 +90,6 @@ def timestamp(event):
     )
 
 def test_memfault(dut_board, debug_hex_file):
-    if dut_board.device_type != 'thingy91x':
-        pytest.skip("Memfault testing requires debug build which is only available for thingy91x")
-
     # Save timestamp of latest coredump
     coredumps = get_latest_coredump_traces(IMEI)
     logger.debug(f"Found coredumps: {coredumps}")


### PR DESCRIPTION
MEMFAULT_CDR_MAX_ENCODED_METADATA_LEN controls maximum space for custom data header. Too long memfault fw type and version prefixes overflow it. Reducing those fixes the issue.