### PR TITLE
modules: cloud: Trigger initial update to Memfault

### DIFF
--- a/app/src/modules/cloud/cloud_module.c
+++ b/app/src/modules/cloud/cloud_module.c
@@ -426,6 +426,19 @@ static void state_connected_entry(void *o)
 
 	LOG_DBG("%s", __func__);
 	LOG_INF("Connected to Cloud");
+
+#if defined(CONFIG_MEMFAULT)
+	if (memfault_coredump_has_valid_coredump(NULL)) {
+		/* Initial update to Memfault is handled internally in the
+		 * Memfault LTE coredump layer.
+		 */
+		return;
+	}
+
+	/* No coredump available, trigger an initial update to Memfault. */
+	(void)memfault_metrics_heartbeat_debug_trigger();
+	(void)memfault_zephyr_port_post_data();
+#endif /* CONFIG_MEMFAULT */
 }
 
 static void state_connected_exit(void *o)


### PR DESCRIPTION
Trigger an initial update to Memfault.
If a coredump is available, the Memfault LTE coredump library will take care of sending an initial update to Memfault upon connection.

After the initial update, the periodic Memfault update routine will update metrics every MEMFAULT_HTTP_PERIODIC_UPLOAD_INTERVAL_SECS (default: 3600 seconds).