### PR TITLE
CI: Improve test handling

### DIFF
--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -185,27 +185,6 @@ jobs:
           MEMFAULT_PROJECT_SLUG: ${{ vars.MEMFAULT_PROJECT_SLUG }}
           APP_BUNDLEID: ${{ env.APP_BUNDLEID }}
 
-      - name: Test Patched Firmware
-        if: ${{ matrix.device == 'thingy91x' && endsWith(inputs.artifact_fw_version, '-patched') }}
-        working-directory: asset-tracker-template/tests/on_target
-        run: |
-          pytest -v \
-            --junit-xml=results/test-results-patched.xml \
-            --html=results/test-results-patched.html --self-contained-html \
-            tests/test_functional/test_patched.py
-        shell: bash
-        env:
-          SEGGER: ${{ env.RUNNER_SERIAL_NUMBER }}
-          DUT_DEVICE_TYPE: ${{ vars.DUT_DEVICE_TYPE }}
-          UUID: ${{ env.UUID }}
-          NRFCLOUD_API_KEY: ${{ secrets.NRF_CLOUD_API_KEY }}
-          LOG_FILENAME: att_test_log_patched
-          TEST_REPORT_NAME: ATT Patched Firwmare Test Report
-          MEMFAULT_ORGANIZATION_TOKEN: ${{ secrets.MEMFAULT_ORGANIZATION_TOKEN }}
-          MEMFAULT_ORGANIZATION_SLUG: ${{ vars.MEMFAULT_ORGANIZATION_SLUG }}
-          MEMFAULT_PROJECT_SLUG: ${{ vars.MEMFAULT_PROJECT_SLUG }}
-          APP_BUNDLEID: ${{ env.APP_BUNDLEID }}
-
       - name: Generate and Push Power Badge
         if: ${{ matrix.device }} == ppk_thingy91x
         continue-on-error: true

--- a/tests/on_target/tests/pytest.ini
+++ b/tests/on_target/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    mqtt: marks tests that require MQTT functionality

--- a/tests/on_target/tests/test_functional/test_mqtt.py
+++ b/tests/on_target/tests/test_functional/test_mqtt.py
@@ -13,6 +13,7 @@ from utils.logger import get_logger
 
 logger = get_logger()
 
+@pytest.mark.mqtt
 @pytest.mark.slow
 def test_mqtt_firmware(dut_board, hex_file_mqtt):
     """Test the firmware with cloud MQTT module."""


### PR DESCRIPTION
This pull request makes changes to the testing configuration and test suite for on-target firmware tests. The most significant updates involve removing a specific test job for patched firmware, introducing a new pytest marker for MQTT-related tests, and applying this marker to an existing test.

### Testing workflow updates:

* [`.github/workflows/target-test.yml`](diffhunk://#diff-70666865fb5fbc611086c2fd040c542baa487438cba3a2103e6a3749092c6a26L188-L208): Removed the "Test Patched Firmware" job from the GitHub Actions workflow. This job previously ran functional tests for patched firmware versions on the `thingy91x` device. The test is still run on-commit we just don't need a separate workflow for it.

### Pytest configuration and test updates:

* [`tests/on_target/tests/pytest.ini`](diffhunk://#diff-a4d0403b78b365b64667155d6be0c4a05c27ee3902f95efeed34f20c1912e0d2R4): Added a new `mqtt` marker to categorize tests that require MQTT functionality.
* [`tests/on_target/tests/test_functional/test_mqtt.py`](diffhunk://#diff-134fdb4adf2dc73c0838d874917de6aacc9dc46cde7f3e57bda129d4c94a681bR16): Applied the new `mqtt` marker to the `test_mqtt_firmware` function, which tests firmware with the cloud MQTT module.