### PR TITLE
tests: module: fix sonarcloud

### DIFF
--- a/tests/module/cloud/src/cloud_module_test.c
+++ b/tests/module/cloud/src/cloud_module_test.c
@@ -110,6 +110,9 @@ static void cloud_chan_cb(const struct zbus_channel *chan)
 	}
 }
 
+/* Static observer node for zbus */
+static struct zbus_observer_node obs_node;
+
 void setUp(void)
 {
 	const struct zbus_channel *chan;
@@ -130,7 +133,7 @@ void setUp(void)
 	zbus_sub_wait(&led, &chan, K_NO_WAIT);
 	zbus_sub_wait(&battery, &chan, K_NO_WAIT);
 
-	zbus_chan_add_obs(&CLOUD_CHAN, &cloud_test_listener, K_NO_WAIT);
+	zbus_chan_add_obs(&CLOUD_CHAN, &cloud_test_listener, &obs_node, K_NO_WAIT);
 }
 
 void test_initial_transition_to_disconnected(void)

--- a/tests/module/cloud_mqtt/src/cloud_mqtt_test.c
+++ b/tests/module/cloud_mqtt/src/cloud_mqtt_test.c
@@ -149,6 +149,9 @@ static void publish_test_payload(void)
 	k_sleep(K_MSEC(100));
 }
 
+/* Static observer node for zbus */
+static struct zbus_observer_node obs_node;
+
 void setUp(void)
 {
 	/* Reset fakes */
@@ -165,7 +168,7 @@ void setUp(void)
 	hw_id_get_fake.custom_fake = hw_id_get_custom_fake;
 	mqtt_helper_init_fake.custom_fake = mqtt_helper_init_custom_fake;
 
-	zbus_chan_add_obs(&CLOUD_CHAN, &cloud_test_listener, K_NO_WAIT);
+	zbus_chan_add_obs(&CLOUD_CHAN, &cloud_test_listener, &obs_node, K_NO_WAIT);
 }
 
 void tearDown(void)


### PR DESCRIPTION
zbus_chan_add_obs needs zbus_observer_node argument.