### PR TITLE
workflows: fix memory badges push

### DIFF
--- a/.github/workflows/build-and-target-test.yml
+++ b/.github/workflows/build-and-target-test.yml
@@ -27,16 +27,18 @@ jobs:
     outputs:
       devices: ${{ steps.setup.outputs.devices }}
       build_all: ${{ steps.setup.outputs.build_all == 'true' }}
+      push_memory_badges: ${{ steps.setup.outputs.push_memory_badges == 'true' }}
     steps:
       - name: Setup
         id: setup
         run: |
           SCHEDULED=${{ github.event_name == 'schedule' }}
           PUSH=${{ github.event_name == 'push' }}
-          BUILD_ALL=${{ inputs.build_all }}
+          push_memory_badges=false
           if [[ $SCHEDULED == true ]]; then
             devices='["thingy91x","nrf9151dk","ppk_thingy91x"]'
             build_all=true
+            push_memory_badges=true
           elif [[ $PUSH == true ]]; then
             devices='["thingy91x"]'
             build_all=false
@@ -46,8 +48,10 @@ jobs:
           fi
           echo "devices=$devices"
           echo "build_all=$build_all"
+          echo "push_memory_badges=$push_memory_badges"
           echo "devices=$devices" >> $GITHUB_OUTPUT
           echo "build_all=$build_all" >> $GITHUB_OUTPUT
+          echo "push_memory_badges=$push_memory_badges" >> $GITHUB_OUTPUT
   build:
     needs: setup
     uses: ./.github/workflows/build.yml
@@ -67,3 +71,4 @@ jobs:
       artifact_run_id: ${{ needs.build.outputs.run_id }}
       devices: ${{ needs.setup.outputs.devices }}
       test_all: ${{ needs.setup.outputs.build_all == 'true' }}
+      push_memory_badges: ${{ needs.setup.outputs.push_memory_badges == 'true' }}

--- a/.github/workflows/ncsref-update.yaml
+++ b/.github/workflows/ncsref-update.yaml
@@ -23,6 +23,9 @@ jobs:
     with:
       artifact_fw_version: ${{ needs.build.outputs.version }}
       artifact_run_id: ${{ needs.build.outputs.run_id }}
+      devices: '["thingy91x"]'
+      test_all: true
+      push_memory_badges: false
   update-pr-state:
     needs: [build, test]
     runs-on: ubuntu-latest

--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -48,6 +48,11 @@ on:
         type: string
         required: true
         default: '[\"thingy91x\"]'
+      push_memory_badges:
+        description: Whether or not to parse thingy91x build log and push memory badges
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   target_test:
@@ -116,7 +121,7 @@ jobs:
               asset-tracker-template-${{ inputs.artifact_fw_version }}-debug-${{ vars.DUT_DEVICE_TYPE }}-nrf91.elf
 
       - name: Generate and Push RAM and FLASH Badges
-        if: ${{ matrix.device == 'thingy91x' && github.event_name == 'schedule' }}
+        if: ${{ matrix.device == 'thingy91x' && inputs.push_memory_badges }}
         continue-on-error: true
         working-directory: asset-tracker-template
         env:


### PR DESCRIPTION
This changes fixes the logic for pushing nightly memory badges.