### PR TITLE
workflows: fix patched build log name

### DIFF
--- a/.github/actions/build-step/action.yml
+++ b/.github/actions/build-step/action.yml
@@ -35,6 +35,10 @@ inputs:
     type: boolean
     required: false
     default: false
+  patched:
+    type: boolean
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -66,6 +70,10 @@ runs:
             -d build \
             -p --sysbuild \
             -- -DEXTRA_CONF_FILE="$(pwd)/../examples/modules/cloud/overlay-mqtt.conf" 2>&1 | tee ../../artifacts/build_output_${{ inputs.short_board }}_mqtt.log
+        elif [[ "${{ inputs.patched }}" == "true" ]]; then
+          west build -b ${{ inputs.board }} \
+            -d build \
+            -p --sysbuild 2>&1 | tee ../../artifacts/build_output_${{ inputs.short_board }}_patched.log
         else
           west build -b ${{ inputs.board }} \
             -d build \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,7 @@ jobs:
           short_board: thingy91x
           version: ${{ env.VERSION }}-patched
           path: asset-tracker-template/app
+          patched: true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fix for patched build log that overwrites the normal build log. This messes up memory charts and badges.