### PR TITLE
readme: add memory sunburst to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 [![Power Consumption Badge](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/power_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/power_measurements_plot.html)
 
 [![RAM Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/ram_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/ram_history_plot.html)
-[![Flash Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/flash_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/flash_history_plot.html)
+[![RAM Sunburst](https://img.shields.io/badge/🔗_RAM_Report-Sunburst_View-blue)](https://nrfconnect.github.io/Asset-Tracker-Template/ram_memory_sunburst.html)
+
+[![FLASH Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/flash_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/flash_history_plot.html)
+[![FLASH Sunburst](https://img.shields.io/badge/🔗_FLASH_Report-Sunburst_View-blue)](https://nrfconnect.github.io/Asset-Tracker-Template/rom_memory_sunburst.html)
 
 ## Overview
 

--- a/tests/on_target/scripts/parse_memory_stats.py
+++ b/tests/on_target/scripts/parse_memory_stats.py
@@ -57,8 +57,8 @@ def parse_memory_stats(log_file, output_dir=None):
     ram_badge_file = os.path.join(output_dir, "ram_badge.json")
     flash_badge_file = os.path.join(output_dir, "flash_badge.json")
 
-    create_badge_json("RAM Usage thingy91x", ram_used, ram_total, ram_percent, ram_badge_file)
-    create_badge_json("Flash Usage thingy91x", flash_used, flash_total, flash_percent, flash_badge_file)
+    create_badge_json("🔗 RAM Usage thingy91x", ram_used, ram_total, ram_percent, ram_badge_file)
+    create_badge_json("🔗 FLASH Usage thingy91x", flash_used, flash_total, flash_percent, flash_badge_file)
 
     print("Memory Usage Statistics:")
     print(f"FLASH: {flash_used:,} B / {flash_total:,} B ({flash_percent:.2f}%)")


### PR DESCRIPTION
Add two badges in the readme that point to memory sunburst in gh-pages.