### PR TITLE
workflows: add sunburst memory report to ci

### DIFF
--- a/.github/actions/build-step/action.yml
+++ b/.github/actions/build-step/action.yml
@@ -39,6 +39,10 @@ inputs:
     type: boolean
     required: false
     default: false
+  push_memory_badges:
+    type: boolean
+    required: false
+    default: false
 
 runs:
   using: "composite"
@@ -78,12 +82,19 @@ runs:
           west build -b ${{ inputs.board }} \
             -d build \
             -p --sysbuild 2>&1 | tee ../../artifacts/build_output_${{ inputs.short_board }}.log
+          if [[ "${{ inputs.short_board }}" == "thingy91x" ]]; then
+            if [[ "${{ inputs.push_memory_badges }}" == "true" ]]; then
+              west build -d build/app -t rom_report
+              west build -d build/app -t ram_report
+              cp build/app/rom.json ../../artifacts/rom_report_${{ inputs.short_board }}.json
+              cp build/app/ram.json ../../artifacts/ram_report_${{ inputs.short_board }}.json
+            fi
+          fi
         fi
 
     - name: Copy artifacts
       shell: bash
       run: |
-        mkdir -p artifacts
         cp ${{ inputs.path }}/build/merged.hex \
           artifacts/asset-tracker-template-${{ inputs.version }}-${{ inputs.short_board }}-nrf91.hex
         cp ${{ inputs.path }}/build/app/zephyr/.config \

--- a/.github/workflows/build-and-target-test.yml
+++ b/.github/workflows/build-and-target-test.yml
@@ -58,6 +58,7 @@ jobs:
     secrets: inherit
     with:
       build_all: ${{ needs.setup.outputs.build_all == 'true' }}
+      push_memory_badges: ${{ needs.setup.outputs.push_memory_badges == 'true' }}
   test:
     permissions:
       actions: read
@@ -71,4 +72,3 @@ jobs:
       artifact_run_id: ${{ needs.build.outputs.run_id }}
       devices: ${{ needs.setup.outputs.devices }}
       test_all: ${{ needs.setup.outputs.build_all == 'true' }}
-      push_memory_badges: ${{ needs.setup.outputs.push_memory_badges == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
         type: boolean
         required: false
         default: false
+      push_memory_badges:
+        description: Whether to parse thingy91x build log and push memory badges
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       memfault_fw_type:
@@ -24,6 +29,10 @@ on:
         required: false
         default: false
       build_all:
+        type: boolean
+        required: false
+        default: false
+      push_memory_badges:
         type: boolean
         required: false
         default: false
@@ -130,6 +139,27 @@ jobs:
           short_board: thingy91x
           version: ${{ env.VERSION }}
           path: asset-tracker-template/app
+          push_memory_badges: ${{ inputs.push_memory_badges }}
+
+      - name: Generate Memory Reports and Visualizations
+        if: ${{ inputs.push_memory_badges }}
+        continue-on-error: true
+        working-directory: asset-tracker-template
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Install required packages
+          pip install pandas plotly --break-system-packages
+          
+          # Generate sunburst charts first
+          python3 scripts/sunburst_from_mem_report.py ../artifacts/rom_report_thingy91x.json
+          python3 scripts/sunburst_from_mem_report.py ../artifacts/ram_report_thingy91x.json
+          
+          # Generate badges, history plots, and push everything to gh-pages
+          ./tests/on_target/scripts/update_memory_badges.sh \
+              ../artifacts/build_output_thingy91x.log \
+              ../artifacts/rom_report_thingy91x.html \
+              ../artifacts/ram_report_thingy91x.html
 
       - name: Build (old) thingy91 firmware
         if: ${{ inputs.build_all }}

--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -22,11 +22,6 @@ on:
         type: string
         required: true
         default: '[\"thingy91x\"]'
-      push_memory_badges:
-        type: boolean
-        required: false
-        default: false
-
 
   workflow_dispatch:
     inputs:
@@ -53,11 +48,6 @@ on:
         type: string
         required: true
         default: '[\"thingy91x\"]'
-      push_memory_badges:
-        description: Whether or not to parse thingy91x build log and push memory badges
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   target_test:
@@ -124,14 +114,6 @@ jobs:
               upload-mcu-symbols \
               --check-uploaded \
               asset-tracker-template-${{ inputs.artifact_fw_version }}-debug-${{ vars.DUT_DEVICE_TYPE }}-nrf91.elf
-
-      - name: Generate and Push RAM and FLASH Badges
-        if: ${{ matrix.device == 'thingy91x' && inputs.push_memory_badges }}
-        continue-on-error: true
-        working-directory: asset-tracker-template
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./tests/on_target/scripts/update_memory_badges.sh tests/on_target/artifacts/build_output_thingy91x.log
 
       - name: Target Tests
         working-directory: asset-tracker-template/tests/on_target

--- a/README.md
+++ b/README.md
@@ -9,11 +9,8 @@
 [![Target_tests](https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml/badge.svg?event=schedule)](https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Aschedule)
 [![Power Consumption Badge](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/power_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/power_measurements_plot.html)
 
-[![RAM Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/ram_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/ram_history_plot.html)
-[![RAM Sunburst](https://img.shields.io/badge/🔗_RAM_Report-Sunburst_View-blue)](https://nrfconnect.github.io/Asset-Tracker-Template/ram_memory_sunburst.html)
-
-[![FLASH Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/flash_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/flash_history_plot.html)
-[![FLASH Sunburst](https://img.shields.io/badge/🔗_FLASH_Report-Sunburst_View-blue)](https://nrfconnect.github.io/Asset-Tracker-Template/rom_memory_sunburst.html)
+[![RAM Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/ram_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/ram_memory_view.html)
+[![FLASH Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/flash_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/flash_memory_view.html)
 
 ## Overview
 

--- a/scripts/sunburst_from_mem_report.py
+++ b/scripts/sunburst_from_mem_report.py
@@ -34,6 +34,9 @@ def create_sunburst_from_json(json_path, output_html=None):
     records = flatten(root)
     df = pd.DataFrame(records)
 
+    # Determine if it's RAM or ROM from filename
+    memory_type = "RAM" if "ram" in json_path.lower() else "ROM"
+
     # Create sunburst chart with children filling full parent
     fig = px.sunburst(
         df,
@@ -41,10 +44,10 @@ def create_sunburst_from_json(json_path, output_html=None):
         names='label',
         parents='parent',
         values='value',
-        title='Memory Usage Sunburst',
+        title=f'{memory_type} Memory Usage Sunburst',
         branchvalues='total'  # ensure children sum to full parent
     )
-    fig.update_layout(margin=dict(t=30, l=0, r=0, b=0))
+    fig.update_layout(margin=dict(t=80, l=0, r=0, b=0))
 
     if output_html:
         fig.write_html(output_html, include_plotlyjs='cdn', full_html=True)

--- a/tests/on_target/scripts/update_memory_badges.sh
+++ b/tests/on_target/scripts/update_memory_badges.sh
@@ -2,6 +2,8 @@
 
 # Define paths
 BUILD_LOG=$1
+ROM_REPORT=$2
+RAM_REPORT=$3
 
 FLASH_BADGE_FILE_DEST=docs/flash_badge.json
 RAM_BADGE_FILE_DEST=docs/ram_badge.json
@@ -9,9 +11,12 @@ FLASH_HISTORY_CSV_DEST=docs/flash_history.csv
 RAM_HISTORY_CSV_DEST=docs/ram_history.csv
 FLASH_PLOT_HTML_DEST=docs/flash_history_plot.html
 RAM_PLOT_HTML_DEST=docs/ram_history_plot.html
+ROM_REPORT_DEST=docs/rom_report_thingy91x.html
+RAM_REPORT_DEST=docs/ram_report_thingy91x.html
 
-if [ -z "$BUILD_LOG" ]; then
-    echo "Error: Build log file path not provided"
+if [ -z "$BUILD_LOG" ] || [ -z "$ROM_REPORT" ] || [ -z "$RAM_REPORT" ]; then
+    echo "Error: Missing required arguments"
+    echo "Usage: $0 <build_log> <rom_report> <ram_report>"
     exit 0
 fi
 
@@ -62,10 +67,13 @@ mkdir -p docs
 cp "$TEMP_DIR"/*.json docs/
 cp "$TEMP_DIR"/*.csv docs/
 cp "$TEMP_DIR"/*.html docs/
+cp "$ROM_REPORT" "$ROM_REPORT_DEST"
+cp "$RAM_REPORT" "$RAM_REPORT_DEST"
 
 git add $FLASH_BADGE_FILE_DEST $RAM_BADGE_FILE_DEST \
     $FLASH_HISTORY_CSV_DEST $RAM_HISTORY_CSV_DEST \
-    $FLASH_PLOT_HTML_DEST $RAM_PLOT_HTML_DEST
+    $FLASH_PLOT_HTML_DEST $RAM_PLOT_HTML_DEST \
+    $ROM_REPORT_DEST $RAM_REPORT_DEST
 git commit -m "Update memory usage badges"
 git push origin gh-pages
 


### PR DESCRIPTION
Memory reports are now built and pushed nightly.
Also, single memory badge added, linking to split view of memory history and report.