### PR TITLE
workflow: compliance: Force install junitparser 2.8.0.

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Install zephyr requirements
         run: |
           pip install -r zephyr/scripts/requirements-compliance.txt
+          # Junitparser v3 and 4 don't work with check_compliance.py
+          pip install --upgrade junitparser==2.8.0
 
       - name: Run Compliance Tests
         id: compliance


### PR DESCRIPTION
Compliance does not work with v3 or v4 editions.