### PR TITLE
modules: network: Increase thread stack size

### DIFF
--- a/app/src/modules/network/Kconfig.network
+++ b/app/src/modules/network/Kconfig.network
@@ -15,7 +15,7 @@ config APP_NETWORK_SHELL
 
 config APP_NETWORK_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 1664
+	default 2048
 
 config APP_NETWORK_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout"


### PR DESCRIPTION
Fault in Memfault showed the nw thread being at 96 percentage during hardfault. Increase the stack size to 2048 bytes to avoid potential stack overflow.