### PR TITLE
workflows: fix sonarcloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,6 +48,12 @@ jobs:
 
       - name: Install dependencies
         run: |
+            # The Matter IDL is part of requirements-build.txt, but it's not available
+            # in pypi so we need to install it from the source code
+            MATTER_IDL_PATH=modules/lib/matter/scripts/py_matter_idl
+            if [ -d $MATTER_IDL_PATH ]; then
+              pip install -e $MATTER_IDL_PATH
+            fi
             pip install -r nrf/scripts/requirements-build.txt
             apt-get update
             apt install -y curl ruby-full


### PR DESCRIPTION
Manually install matter_idl before installing requirements-build.txt.