### PR TITLE
tests: on_target: new app fota bundle

### DIFF
--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -148,7 +148,7 @@ jobs:
           MEMFAULT_ORGANIZATION_TOKEN: ${{ secrets.MEMFAULT_ORGANIZATION_TOKEN }}
           MEMFAULT_ORGANIZATION_SLUG: ${{ vars.MEMFAULT_ORGANIZATION_SLUG }}
           MEMFAULT_PROJECT_SLUG: ${{ vars.MEMFAULT_PROJECT_SLUG }}
-          APP_BUNDLEID: ${{ env.APP_BUNDLEID }}
+          APP_BUNDLEID: ${{ vars.APP_BUNDLEID }}
 
       - name: Generate and Push Power Badge
         if: ${{ matrix.device }} == ppk_thingy91x

--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -18,7 +18,7 @@ logger = get_logger()
 MFW_202_FILEPATH = "artifacts/mfw_nrf91x1_2.0.2.zip"
 
 # Stable version used for testing
-TEST_APP_VERSION = "0.0.0-foo"
+TEST_APP_VERSION = "1.0.2"
 
 DELTA_MFW_BUNDLEID = "59cec896-c842-40fe-9a95-a4f3e88a4cdb"
 FULL_MFW_BUNDLEID = "d692915d-d978-4c77-ab02-f05f511971f9"


### PR DESCRIPTION
Update fota bundle to use relese 1.0.2 bin file.
Also, APP_BUNDLEID should be vars., not env., in workflow file.