### PR TITLE
modules: power: Initialize struct to prevent uninitialized value usage

### DIFF
--- a/app/src/modules/power/power.c
+++ b/app/src/modules/power/power.c
@@ -290,7 +290,7 @@ static int subscribe_to_vsbus_events(const struct device *device, struct gpio_ca
 
 static int charger_read_sensors(float *voltage, float *current, float *temp, int32_t *chg_status)
 {
-	struct sensor_value value;
+	struct sensor_value value = {0};
 	int err;
 
 	err = sensor_sample_fetch(charger);


### PR DESCRIPTION
Fixed a Valgrind error where an uninitialized sensor_value struct in charger_read_sensors() was being used in conditional operations. Added zero-initialization of the struct to ensure all fields have defined values before being passed to sensor_channel_get().