### PR TITLE
docs: Add modem tracing instructions

### DIFF
--- a/app/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/app/boards/nrf9151dk_nrf9151_ns.overlay
@@ -7,6 +7,7 @@
 / {
 	/* Configure partition manager to use gd25wb256 as the external flash */
 	chosen {
+		nordic,modem-trace-uart = &uart1;
 		nordic,pm-ext-flash = &gd25wb256;
 	};
 
@@ -21,4 +22,5 @@
 
 &uart1 {
 	status = "okay";
+	current-speed = <1000000>;
 };

--- a/app/boards/thingy91x_nrf9151_ns.overlay
+++ b/app/boards/thingy91x_nrf9151_ns.overlay
@@ -12,14 +12,15 @@
 
 / {
 	chosen {
+		nordic,modem-trace-uart = &uart1;
 		zephyr,wifi = &nordic_wlan0;
 	};
 };
 
 &uart1 {
 	status = "okay";
+	current-speed = <1000000>;
 };
-
 
 /* Switch to nrf7000 emulation so that scan-only mode is used. */
 &nrf70 {


### PR DESCRIPTION
- Add section for dumping modem traces from flash to UART
- Add table of contents for better navigation
- Improve formatting and fix typos throughout the document
- Add missing DTS entries for modem tracing