### PR TITLE
docs: Remove reference to Quickstart app for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,16 @@ For detailed setup instructions using the [nRF Connect for VS Code extension](ht
 <summary>1. <strong>Initialize workspace:</strong></summary>
 
 ```shell
+# Install nRF Util
+pip install nrfutil
+
+# or follow install [documentation](https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html)
+
+# Install toolchain
+nrfutil toolchain-manager install --ncs-version v3.1.0
+
 # Launch toolchain
-nrfutil sdk-manager toolchain launch --ncs-version v3.0.0 --shell
+nrfutil toolchain-manager launch --ncs-version v3.1.0 --shell
 
 # Initialize workspace
 west init -m https://github.com/nrfconnect/Asset-Tracker-Template.git --mr main asset-tracker-template
@@ -49,10 +57,17 @@ west update
 <details>
 <summary>2. <strong>Build and flash:</strong></summary>
 
+**For Thingy:91 X:**
 ```shell
 west build --pristine --board thingy91x/nrf9151/ns
 west thingy91x-dfu  # For Thingy:91 X serial bootloader
 # Or with external debugger:
+west flash --erase
+```
+
+**For nRF9151 DK:**
+```shell
+west build --pristine --board nrf9151dk/nrf9151/ns
 west flash --erase
 ```
 </details>
@@ -60,7 +75,19 @@ west flash --erase
 <details>
 <summary>3. <strong>Provision device:</strong></summary>
 
-Use [nRF Connect for Desktop Quickstart](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) to provision the device for nRF Cloud CoAP connectivity. See [Provisioning](docs/common/provisioning.md) for details.
+1. Get the device attestation token over terminal shell:
+
+   ```bash
+   at at%attesttoken?
+   ```
+
+   *Note: Token is printed automatically on first boot of unprovisioned devices.*
+
+2. In nRF Cloud: **Security Services** → **Claimed Devices** → **Claim Device**
+3. Paste token, set rule to "nRF Cloud Onboarding", click **Claim Device**
+4. Wait for the device to provision credentials and connect to nRF Cloud over CoAP.
+
+See [Provisioning](docs/common/provisioning.md) for more details.
 </details>
 
 ## System Architecture

--- a/docs/common/getting_started.md
+++ b/docs/common/getting_started.md
@@ -126,7 +126,6 @@ west build -p -b thingy91x/nrf9151/ns -- -DEXTRA_CONF_FILE="overlay-memfault.con
 
 To connect to [nRF Cloud](https://nrfcloud.com), the device must be provisioned to your account. You can provision the device using one of the following methods:
 
-* **Quickstart application**: Use the [nRF Connect for Desktop Quickstart application](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) for a streamlined setup process.
 * **Manual provisioning**: Follow the detailed steps in the [Provisioning](provisioning.md) documentation.
 
 The provisioning process establishes the necessary credentials and certificates for secure communication between your device and nRF Cloud.

--- a/docs/common/provisioning.md
+++ b/docs/common/provisioning.md
@@ -2,10 +2,6 @@
 
 Device provisioning establishes credentials for secure communication with nRF Cloud CoAP.
 
-## Quick Start
-
-**Recommended**: Use [nRF Connect for Desktop Quickstart](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) for guided setup.
-
 ## Manual Provisioning
 
 1. Get the device attestation token:
@@ -30,7 +26,9 @@ curl 'https://api.provisioning.nrfcloud.com/v1/claimed-devices' \
 
 ## Reprovisioning
 
-To update device credentials for security:
+To update device credentials:
+
+> In an end-product it's recommended to reprovision the device at a reasonable interval depending on the application use case, for security reasons.
 
 ### Manual
 


### PR DESCRIPTION
Remove reference to Quickstart app for now. Will be readded once Quickstart support ATT.