### PR TITLE
ci: fix ci for gnss_nrf9151dk

### DIFF
--- a/.github/actions/build-step/action.yml
+++ b/.github/actions/build-step/action.yml
@@ -68,6 +68,10 @@ runs:
         if [[ "${{ inputs.modem_trace }}" == "true" ]]; then
           params+=("-Dapp_SNIPPET=nrf91-modem-trace-uart")
         fi
+        if [[ "${{ inputs.board }}" == "nrf9151dk"* ]]; then
+          echo CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y >> overlay-nrf9151dk.conf
+          params+=("-DEXTRA_CONF_FILE=overlay-nrf9151dk.conf")
+        fi
         west build -b ${{ inputs.board }} \
             -d build \
             -p --sysbuild -- \

--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -837,10 +837,23 @@ static void state_connecting_provisioned_run(void *obj)
 static void state_connecting_provisioning_entry(void *obj)
 {
 	int err;
-
 	struct cloud_state_object *state_object = obj;
+	struct location_msg location_msg = {
+		.type = LOCATION_SEARCH_CANCEL,
+	};
 
 	LOG_DBG("%s", __func__);
+
+	/* Cancel any ongoing location search during provisioning to allow writing credentials,
+	 * which requires offline LTE functional mode.
+	 */
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, K_SECONDS(1));
+	if (err) {
+		LOG_ERR("zbus_chan_pub, error: %d", err);
+
+		SEND_FATAL_ERROR();
+		return;
+	}
 
 	state_object->provisioning_ongoing = true;
 

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -212,6 +212,8 @@ static void handle_location_chan(const struct location_msg *location_msg)
 			LOG_ERR("Unable to cancel location request: %d", err);
 		} else {
 			LOG_DBG("Location request cancelled successfully");
+
+			gnss_disable();
 		}
 	}
 }

--- a/tests/on_target/tests/test_gnss/test_gnss.py
+++ b/tests/on_target/tests/test_gnss/test_gnss.py
@@ -5,7 +5,7 @@
 
 import os
 import pytest
-from utils.flash_tools import flash_device, reset_device, recover_device
+from utils.flash_tools import flash_device, reset_device
 import sys
 sys.path.append(os.getcwd())
 from utils.logger import get_logger
@@ -44,6 +44,6 @@ def test_gnss(dut_board, hex_file):
     assert abs(lat - 61.493219) < 0.1, f"Latitude {lat} is not within expected range of 61.493219"
     assert abs(lon - 23.771307) < 0.1, f"Longitude {lon} is not within expected range of 23.771307"
     assert acc > 0, f"Accuracy {acc} should be greater than 0"
-    assert "Cellular" in method, f"Method '{method}' should be 'Cellular'"
+    assert "GNSS" in method, f"Method '{method}' should be 'GNSS'"
 
     logger.info(f"Got location: lat: {lat}, lon: {lon}, acc: {acc}, method: {method}")

--- a/tests/on_target/tests/test_provisioning/test_provisioning.py
+++ b/tests/on_target/tests/test_provisioning/test_provisioning.py
@@ -145,32 +145,6 @@ def _wait_for_provisioning_completion_and_cloud_connection(
     logger.info("Device provisioned and connected to nRF Cloud.")
 
 
-def _verify_device_location_data(
-    dut_cloud,
-    expected_lat: float = 61.5,
-    expected_lon: float = 10.5,
-    lat_tolerance: float = 2.0,
-    lon_tolerance: float = 1.0,
-    timeout: int = 300,
-):
-    logger.info("Verifying device location data...")
-
-    values = dut_cloud.uart.wait_for_str_re(
-        r"Got location: lat: ([\d.-]+), lon: ([\d.-]+), acc: ([\d.-]+), method:",
-        timeout=timeout
-    )
-    assert values, "Failed to get location data from device."
-
-    lat_str, lon_str, acc_str = values
-    lat, lon = float(lat_str), float(lon_str)
-    logger.info(f"Received location: Lat={lat}, Lon={lon}, Accuracy={acc_str}")
-
-    assert abs(lat - expected_lat) < lat_tolerance, f"Latitude {lat} out of range."
-    assert abs(lon - expected_lon) < lon_tolerance, f"Longitude {lon} out of range."
-
-    logger.info("Device location data verified.")
-
-
 def _trigger_device_reprovisioning_with_new_credentials(dut_cloud, sec_tag: int):
     """
     Initiates the reprovisioning process on the device by:
@@ -249,7 +223,6 @@ def _run_initial_provisioning(dut_cloud, hex_file):
     _connect_to_network_and_wait_for_claiming_prompt(dut_cloud)
     _claim_device_on_nrf_cloud(dut_cloud, attestation_token)
     _wait_for_provisioning_completion_and_cloud_connection(dut_cloud)
-    _verify_device_location_data(dut_cloud)
 
     logger.info("--- Phase 1: Initial Device Provisioning Completed Successfully ---")
 
@@ -262,7 +235,6 @@ def _run_reprovisioning(dut_cloud):
     _trigger_device_reprovisioning_with_new_credentials(dut_cloud, SEC_TAG)
     # Wait for the device to process the command, reprovision, and reconnect
     _wait_for_provisioning_completion_and_cloud_connection(dut_cloud, timeout=300)
-    _verify_device_location_data(dut_cloud)
 
     logger.info(
         "--- Phase 2: Reprovisioning with New Credentials Completed Successfully ---"


### PR DESCRIPTION
- Enable external GNSS antenna for gnss_nrf9151dk board
- Remove verification of location in the provisioning test, as it's not within the scope of the test to verify that GNSS is working.