### PR TITLE
ci: revert board-specific config for nrf9151dk

### DIFF
--- a/.github/actions/build-step/action.yml
+++ b/.github/actions/build-step/action.yml
@@ -68,10 +68,6 @@ runs:
         if [[ "${{ inputs.modem_trace }}" == "true" ]]; then
           params+=("-Dapp_SNIPPET=nrf91-modem-trace-uart")
         fi
-        if [[ "${{ inputs.board }}" == "nrf9151dk"* ]]; then
-          echo CONFIG_MODEM_ANTENNA_GNSS_EXTERNAL=y >> overlay-nrf9151dk.conf
-          params+=("-DEXTRA_CONF_FILE=overlay-nrf9151dk.conf")
-        fi
         west build -b ${{ inputs.board }} \
             -d build \
             -p --sysbuild -- \


### PR DESCRIPTION
Remove external antenna configuration for the DK in CI as it was applied for all images, even prod builds released for the DK in releases.