### PR TITLE
modules: power: add extra battery state to message

### DIFF
--- a/app/src/modules/power/CMakeLists.txt
+++ b/app/src/modules/power/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/power.c)
+target_sources_ifdef(CONFIG_APP_POWER_SHELL app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/power_shell.c)
 target_include_directories(app PRIVATE .)

--- a/app/src/modules/power/Kconfig.power
+++ b/app/src/modules/power/Kconfig.power
@@ -13,6 +13,12 @@ config APP_POWER
 
 if APP_POWER
 
+config APP_POWER_SHELL
+	bool "Power module shell commands"
+	default y if SHELL
+	help
+	  Enable shell commands for the power module.
+
 config APP_POWER_DISABLE_UART_ON_VBUS_REMOVED
 	bool "Disable UART when VBUS is removed"
 	default y

--- a/app/src/modules/power/power.c
+++ b/app/src/modules/power/power.c
@@ -362,10 +362,13 @@ static void sample(int64_t *ref_time)
 
 	LOG_DBG("State of charge: %f", (double)roundf(state_of_charge));
 	LOG_DBG("The battery is %s", charging ? "charging" : "not charging");
+	LOG_DBG("Battery voltage: %f V", (double)voltage);
 
 	struct power_msg msg = {
 		.type = POWER_BATTERY_PERCENTAGE_SAMPLE_RESPONSE,
-		.percentage = (double)roundf(state_of_charge)
+		.percentage = (double)roundf(state_of_charge),
+		.charging = charging,
+		.voltage = (double)voltage,
 	};
 
 #if defined(CONFIG_APP_POWER_TIMESTAMP)

--- a/app/src/modules/power/power.h
+++ b/app/src/modules/power/power.h
@@ -43,6 +43,12 @@ struct power_msg {
 
 	/** Timestamp of the sample in milliseconds since epoch. */
 	int64_t timestamp;
+
+	/** True if the battery is charging, false otherwise. */
+	bool charging;
+
+	/** Voltage in volts. */
+	double voltage;
 };
 
 #define MSG_TO_POWER_MSG(_msg)	(*(const struct power_msg *)_msg)

--- a/app/src/modules/power/power_shell.c
+++ b/app/src/modules/power/power_shell.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/shell/shell.h>
+#include <zephyr/zbus/zbus.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <errno.h>
+
+#include "power.h"
+
+LOG_MODULE_DECLARE(power, CONFIG_APP_POWER_LOG_LEVEL);
+
+static bool sample_requested;
+
+void power_shell_listener_callback(const struct zbus_channel *chan)
+{
+	if (!sample_requested) {
+		return;
+	}
+
+	const struct power_msg *msg = zbus_chan_const_msg(chan);
+
+	if (msg->type == POWER_BATTERY_PERCENTAGE_SAMPLE_RESPONSE) {
+		LOG_INF("Battery state of charge: %.2f%%", msg->percentage);
+		LOG_INF("Battery voltage: %.2fV", msg->voltage);
+		LOG_INF("Charging: %s", msg->charging ? "Yes" : "No");
+		sample_requested = false;
+	}
+}
+
+ZBUS_LISTENER_DEFINE(power_shell_listener, power_shell_listener_callback);
+
+ZBUS_CHAN_ADD_OBS(POWER_CHAN, power_shell_listener, 0);
+
+static int cmd_power_sample(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	int err;
+	struct power_msg msg = {
+		.type = POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST,
+	};
+
+	err = zbus_chan_pub(&POWER_CHAN, &msg, K_NO_WAIT);
+	if (err) {
+		shell_print(shell, "Failed to send request: %d", err);
+		return err;
+	}
+
+	sample_requested = true;
+	shell_print(shell, "Requesting battery sample...");
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_cmds,
+	SHELL_CMD(sample, NULL,
+		  "Request a battery sample (state of charge, voltage, charging state)",
+		  cmd_power_sample),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(att_power, &sub_cmds, "Asset Tracker Template Power CMDs", NULL);


### PR DESCRIPTION
Add extra battery state information to the power module message:
- Voltage
- Whether the battery is charging or not

This data is generally useful to get the full picture of battery state.

For testing, a new shell command is now available to trigger a power
sample:

```
uart:~$ att_power sample
Requesting battery sample...
[00:01:41.007,843] <inf> power: Battery state of charge: 100.00%
[00:01:41.007,873] <inf> power: Battery voltage: 4.19V
[00:01:41.007,904] <inf> power: Charging: No
```

Signed-off-by: Gillian Minnehan <gillian.minnehan@nordicsemi.no>