### PR TITLE
tests: Change expected string in tests

### DIFF
--- a/docs/common/getting_started.md
+++ b/docs/common/getting_started.md
@@ -199,7 +199,7 @@ To test that everything is working as expected, you can do the following:
     [00:00:01.109,924] <dbg> location_module: on_cfun: Modem CFUN mode: 21
     [00:00:03.170,928] <dbg> network: lte_lc_evt_handler: PSM parameters received, TAU: 7200, Active time: 6
     [00:00:03.171,447] <dbg> network: lte_lc_evt_handler: eDRX parameters received, mode: 7, eDRX: 5.12 s, PTW: 1.28 s
-    [00:00:03.171,752] <inf> network: Network connectivity established
+    [00:00:03.171,752] <dbg> network: l4_event_handler: Network connectivity established
     [00:00:03.172,821] <dbg> cloud: state_connecting_entry: state_connecting_entry
     [00:00:03.172,851] <dbg> cloud: state_connecting_attempt_entry: state_connecting_attempt_entry
     [00:00:03.174,224] <dbg> network: state_connected_entry: state_connected_entry

--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -111,7 +111,7 @@ and execute them if any. Can be used to reprovision the device for development p
 uart:~$ att_network disconnect
 [00:00:36.758,758] <dbg> network: state_disconnecting_entry: state_disconnecting_entry
 [00:00:37.196,746] <wrn> network: Not registered, check rejection cause
-[00:00:37.197,021] <inf> network: Network connectivity lost
+[00:00:37.197,021] <dbg> network: l4_event_handler: Network connectivity lost
 [00:00:37.198,608] <dbg> cloud: state_connected_paused_entry: state_connected_paused_entry
 [00:00:37.198,974] <dbg> main: wait_for_trigger_exit: wait_for_trigger_exit
 [00:00:37.199,005] <dbg> main: idle_entry: idle_entry

--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -66,8 +66,8 @@ def run_fota_resumption(dut_fota, fota_type):
     dut_fota.uart.wait_for_str("50%", timeout=timeout_50_percent)
     logger.debug(f"Testing fota resumption on disconnect for {fota_type} fota")
 
-    patterns_lte_offline = ["network: Network connectivity lost"]
-    patterns_lte_normal = ["network: Network connectivity established"]
+    patterns_lte_offline = ["network: l4_event_handler: Network connectivity lost"]
+    patterns_lte_normal = ["network: l4_event_handler: Network connectivity established"]
 
     # LTE disconnect
     dut_fota.uart.flush()
@@ -78,8 +78,8 @@ def run_fota_resumption(dut_fota, fota_type):
     dut_fota.uart.flush()
     dut_fota.uart.write("att_network connect\r\n")
     dut_fota.uart.wait_for_str(patterns_lte_normal, timeout=120)
-    dut_fota.uart.wait_for_str("fota_download: Refuse fragment, restart with offset")
-    dut_fota.uart.wait_for_str("fota_download: Downloading from offset:")
+    dut_fota.uart.wait_for_str("fota_download: Refuse fragment, restart with offset", timeout=600)
+    dut_fota.uart.wait_for_str("fota_download: Downloading from offset:", timeout=600)
 
 def run_fota_reschedule(dut_fota, fota_type):
     dut_fota.uart.wait_for_str("5%", timeout=APP_FOTA_TIMEOUT)

--- a/tests/on_target/tests/test_functional/test_mqtt.py
+++ b/tests/on_target/tests/test_functional/test_mqtt.py
@@ -26,7 +26,7 @@ def test_mqtt_firmware(dut_board, hex_file_mqtt):
     dut_board.uart.xfactoryreset()
 
     # Log patterns to check
-    pattern_connect_to_broker = "network: Network connectivity established"
+    pattern_connect_to_broker = "network: l4_event_handler: Network connectivity established"
     pattern_cloud = "cloud: on_mqtt_connack: MQTT connection established, session present: 0"
 
     # Cloud connection

--- a/tests/on_target/tests/test_functional/test_shell.py
+++ b/tests/on_target/tests/test_functional/test_shell.py
@@ -31,10 +31,10 @@ def test_shell(dut_cloud, hex_file):
         'Sending on payload channel: {"messageType":"DATA","appId":"donald","data":"duck"',
     ]
     patterns_network_disconnected = [
-        "network: Network connectivity lost",
+        "network: l4_event_handler: Network connectivity lost",
     ]
     patterns_network_connected = [
-        "network: Network connectivity established",
+        "network: l4_event_handler: Network connectivity established",
     ]
 
     # Boot

--- a/tests/on_target/tests/test_provisioning/test_provisioning.py
+++ b/tests/on_target/tests/test_provisioning/test_provisioning.py
@@ -31,7 +31,7 @@ def _perform_initial_device_setup_and_factory_reset(dut_cloud, hex_file: str):
 def _wait_for_lte_connection(dut_cloud, timeout: int = 240):
     logger.info("Waiting for device to connect to LTE network...")
 
-    log_pattern_network_connected = "network: Network connectivity established"
+    log_pattern_network_connected = "network: l4_event_handler: Network connectivity established"
     dut_cloud.uart.wait_for_str(
         log_pattern_network_connected,
         timeout=timeout,
@@ -44,7 +44,7 @@ def _wait_for_lte_connection(dut_cloud, timeout: int = 240):
 def _disconnect_network_and_clear_modem_credentials(dut_cloud, sec_tag: int):
     logger.info("Disconnecting network and clearing modem credentials...")
 
-    log_pattern_network_disconnected = "network: Network connectivity lost"
+    log_pattern_network_disconnected = "network: l4_event_handler: Network connectivity lost"
     dut_cloud.uart.write("att_network disconnect\r\n")
     dut_cloud.uart.wait_for_str(
         log_pattern_network_disconnected,
@@ -102,7 +102,7 @@ def _unclaim_device_from_nrf_cloud_if_exists(dut_cloud):
 def _connect_to_network_and_wait_for_claiming_prompt(dut_cloud):
     logger.info("Connecting to network and waiting for device to request claiming...")
 
-    log_pattern_network_connected = "network: Network connectivity established"
+    log_pattern_network_connected = "network: l4_event_handler: Network connectivity established"
     log_pattern_need_claiming = (
         "Claim the device using the device's attestation token on nrfcloud.com"
     )

--- a/tests/on_target/utils/uart.py
+++ b/tests/on_target/utils/uart.py
@@ -15,7 +15,7 @@ from utils.logger import get_logger
 from typing import Union
 
 DEFAULT_UART_TIMEOUT = 60 * 15
-DEFAULT_WAIT_FOR_STR_TIMEOUT = 60 * 5
+DEFAULT_WAIT_FOR_STR_TIMEOUT = 60 * 10
 
 logger = get_logger()
 


### PR DESCRIPTION
Logging for the network module has been changed to dbg. DBG logs include more information than INF logs, and the tests need to be updated to reflect this.

More specifically, when using dbg the function name is included in the log message, which is not the case for inf.