### PR TITLE
modules: power: Don't enable/disable UART on VBUS events

### DIFF
--- a/app/src/modules/power/Kconfig.power
+++ b/app/src/modules/power/Kconfig.power
@@ -21,7 +21,10 @@ config APP_POWER_SHELL
 
 config APP_POWER_DISABLE_UART_ON_VBUS_REMOVED
 	bool "Disable UART when VBUS is removed"
-	default y
+	help
+	  Disable UART when VBUS is removed to save power.
+	  The UART is re-enabled when VBUS is connected again.
+	  This option is disabled by default due to UART hanging when being re-enabled.
 
 config APP_POWER_THREAD_STACK_SIZE
 	int "Thread stack size"

--- a/app/src/modules/power/power.c
+++ b/app/src/modules/power/power.c
@@ -123,13 +123,11 @@ static void state_running_entry(void *obj)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_APP_POWER_DISABLE_UART_ON_VBUS_REMOVED)) {
-		err = subscribe_to_vsbus_events(pmic, &event_cb);
-		if (err) {
-			LOG_ERR("subscribe_to_vsbus_events, error: %d", err);
-			SEND_FATAL_ERROR();
-			return;
-		}
+	err = subscribe_to_vsbus_events(pmic, &event_cb);
+	if (err) {
+		LOG_ERR("subscribe_to_vsbus_events, error: %d", err);
+		SEND_FATAL_ERROR();
+		return;
 	}
 
 	err = charger_read_sensors(&parameters.v0, &parameters.i0, &parameters.t0, &chg_status);
@@ -256,22 +254,26 @@ static void event_callback(const struct device *dev, struct gpio_callback *cb, u
 	if (pins & BIT(NPM13XX_EVENT_VBUS_DETECTED)) {
 		LOG_DBG("VBUS detected");
 
-		err = uart_enable();
-		if (err) {
-			LOG_ERR("uart_enable, error: %d", err);
-			SEND_FATAL_ERROR();
-			return;
+		if (IS_ENABLED(CONFIG_APP_POWER_DISABLE_UART_ON_VBUS_REMOVED)) {
+			err = uart_enable();
+			if (err) {
+				LOG_ERR("uart_enable, error: %d", err);
+				SEND_FATAL_ERROR();
+				return;
+			}
 		}
 	}
 
 	if (pins & BIT(NPM13XX_EVENT_VBUS_REMOVED)) {
 		LOG_DBG("VBUS removed");
 
-		err = uart_disable();
-		if (err) {
-			LOG_ERR("uart_disable, error: %d", err);
-			SEND_FATAL_ERROR();
-			return;
+		if (IS_ENABLED(CONFIG_APP_POWER_DISABLE_UART_ON_VBUS_REMOVED)) {
+			err = uart_disable();
+			if (err) {
+				LOG_ERR("uart_disable, error: %d", err);
+				SEND_FATAL_ERROR();
+				return;
+			}
 		}
 	}
 }

--- a/tests/module/power/src/power_module_test.c
+++ b/tests/module/power/src/power_module_test.c
@@ -20,7 +20,7 @@ FAKE_VALUE_FUNC(int, task_wdt_add, uint32_t, task_wdt_callback_t, void *);
 FAKE_VALUE_FUNC(float, nrf_fuel_gauge_process, float, float, float, float, bool, void *);
 FAKE_VALUE_FUNC(int, charger_read_sensors, float *, float *, float *, int32_t *);
 FAKE_VALUE_FUNC(int, nrf_fuel_gauge_init, const struct nrf_fuel_gauge_init_parameters *, void *);
-FAKE_VALUE_FUNC(int, mfd_npm1300_add_callback, const struct device *, struct gpio_callback *);
+FAKE_VALUE_FUNC(int, mfd_npm13xx_add_callback, const struct device *, struct gpio_callback *);
 FAKE_VALUE_FUNC(int, date_time_now, int64_t *);
 
 ZBUS_MSG_SUBSCRIBER_DEFINE(power_subscriber);


### PR DESCRIPTION
Don't enable/disable UART on VBUS events due to a regression in NCS where the UART hangs after re-enabling.