### PR TITLE
ntn: Use PDN API to configure cellular profiles

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 9c58ea4757b89e22902cbf7b5d785374a929c473
+      revision: pull/25392/head
       import: true


### PR DESCRIPTION
Use the newly added PDN API to configure cellular profiles.