### PR TITLE
main: fix state handling in main

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1516,6 +1516,10 @@ static enum smf_state_result fota_run(void *o)
 				state_object->running_history = STATE_BUFFER_CONNECTED;
 
 				break;
+			case STATE_PASSTHROUGH_DISCONNECTED:
+				state_object->running_history = STATE_PASSTHROUGH_CONNECTED_SAMPLING;
+
+				break;
 			case STATE_PASSTHROUGH_CONNECTED_SAMPLING:
 				__fallthrough;
 			case STATE_BUFFER_CONNECTED:


### PR DESCRIPTION
Persist state if the device connects/disconnects
when FOTA fails before the download is marked as
failed. This will ensure that main returns to the
correct state after a reconnect.