### PR TITLE
fix: cloud: Use correct Wi-Fi AP count for location request

### DIFF
--- a/app/src/modules/cloud/cloud_location.c
+++ b/app/src/modules/cloud/cloud_location.c
@@ -111,7 +111,7 @@ static int wifi_ap_data_construct(struct wifi_scan_info *dest,
 	}
 
 	/* Copy WiFi AP data */
-	for (uint16_t i = 0; i < ap_info_count; i++) {
+	for (uint16_t i = 0; i < src->wifi_cnt; i++) {
 		ap_info[i].rssi = src->wifi_aps[i].rssi;
 		memcpy(ap_info[i].mac,
 		       src->wifi_aps[i].mac,
@@ -120,7 +120,7 @@ static int wifi_ap_data_construct(struct wifi_scan_info *dest,
 	}
 
 	dest->ap_info = ap_info;
-	dest->cnt = ap_info_count;
+	dest->cnt = src->wifi_cnt;
 
 	return 0;
 }


### PR DESCRIPTION
The wifi_ap_data_construct function was incorrectly using the size of the destination buffer instead of the actual number of scanned Wi-Fi access points. This caused uninitialized data with invalid MAC addresses to be sent to nRF Cloud, resulting in a location request failure.

The fix ensures the correct count of scanned APs is used, preventing invalid data from being sent.