### PR TITLE
CI: Block AI workflows on pr from fork

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -9,7 +9,7 @@ permissions: write-all
 jobs:
   code_review:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'ai-review'
+    if: github.event.label.name == 'ai-review' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/verify-state-machine.yml
+++ b/.github/workflows/verify-state-machine.yml
@@ -18,6 +18,7 @@ jobs:
   verify-state-machines:
     name: Verify State Machines
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 15  # Prevent hanging jobs
     container:
       image: python:3.12.5-slim-bookworm


### PR DESCRIPTION
verify-state-machine.yml and ai-review.yaml need access to secrets, so they should not run on PRs from forks. Added run conditions that gates the jobs to only run when the PR is from the same repository.

Helps against situations like #449 where the PR got merged with failing tests due to noise from failing AI workflows