### PR TITLE
memfault: Make battery model header globally available

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -10,8 +10,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project("Asset Tracker Template")
 
 # Include files that are common for all modules
-target_include_directories(app PRIVATE src/common)
-
+zephyr_include_directories(src/common)
 zephyr_include_directories(config)
 
 # Add main application source


### PR DESCRIPTION
The Memfault SDK needs to see the battery model.
Make the common header directory available to all of Zephyr.