### PR TITLE
ntn: Update sdk-nrf reference and use new PDN events

### DIFF
--- a/app/src/modules/ntn/ntn.c
+++ b/app/src/modules/ntn/ntn.c
@@ -14,7 +14,6 @@
 #include <modem/nrf_modem_lib.h>
 #include <modem/ntn.h>
 #include <nrf_modem_at.h>
-#include <modem/at_monitor.h>
 #include <nrf_modem_gnss.h>
 #include <zephyr/task_wdt/task_wdt.h>
 #include <errno.h>
@@ -31,16 +30,6 @@
 #include "button.h"
 
 LOG_MODULE_REGISTER(ntn_module, CONFIG_APP_NTN_LOG_LEVEL);
-
-/* AT monitor for network notifications.
- * The monitor is needed to receive notification when in the case where the modem has been
- * put into offline mode while keeping registration context.
- * In this case, the modem will send a +CEREG notification with status 1 or 5 when NTN is
- * re-enabled. The LTE link controller does not forward this because it is equal to the previous
- * registration status. To work around this, we monitor the +CEREG notification and forward it
- * to the NTN module when offline-while-keeping-registration mode is enabled.
- */
-AT_MONITOR(cereg_monitor, "CEREG", cereg_mon, PAUSED);
 
 /* Define channels provided by this module */
 ZBUS_CHAN_DEFINE(NTN_CHAN,
@@ -177,6 +166,16 @@ static void lte_lc_evt_handler(const struct lte_lc_evt *const evt)
 		case LTE_LC_EVT_PDN_NETWORK_DETACH:
 			LOG_DBG("PDN connection network detached");
 			ntn_msg_publish(NETWORK_DISCONNECTED);
+
+			break;
+		case LTE_LC_EVT_PDN_SUSPENDED:
+			LOG_DBG("PDN connection suspended");
+			ntn_msg_publish(NTN_NETWORK_DISCONNECTED);
+
+			break;
+		case LTE_LC_EVT_PDN_RESUMED:
+			LOG_DBG("PDN connection resumed");
+			ntn_msg_publish(NTN_NETWORK_CONNECTED);
 
 			break;
 		default:
@@ -333,20 +332,6 @@ static void gnss_location_work_handler(struct k_work *work)
 
 /* Helper functions */
 
-static void cereg_mon(const char *notif)
-{
-	enum lte_lc_nw_reg_status status = atoi(notif + (sizeof("+CEREG: ") - 1));
-
-	if ((status == LTE_LC_NW_REG_REGISTERED_ROAMING) ||
-	    (status == LTE_LC_NW_REG_REGISTERED_HOME)) {
-		LOG_DBG("Network registration status: %s",
-			status == LTE_LC_NW_REG_REGISTERED_ROAMING ? "ROAMING" : "HOME");
-		ntn_msg_publish(NETWORK_CONNECTED);
-		LOG_DBG("Stop monitoring incoming CEREG Notifications");
-		at_monitor_pause(&cereg_monitor);
-	}
-}
-
 static int set_ntn_offline_mode(void)
 {
 	int err;
@@ -440,16 +425,6 @@ static int set_ntn_active_mode(struct ntn_state_object *state)
 		return err;
 	}
 #endif
-
-	/* Check if we are in offline-while-keeping-registration mode. If so, the modem has already
-	 * been able to register to an NTN network, which means that the LTE link controller will
-	 * ignore +CEREG notifications with status 1 or 5. To work around this, we monitor the
-	 * +CEREG notifications in the application.
-	 */
-	if (ntn_initialized) {
-		LOG_DBG("Start monitoring incoming CEREG Notifications");
-		at_monitor_resume(&cereg_monitor);
-	}
 
 	LOG_DBG("NTN initialized, activating LTE functional mode");
 
@@ -752,16 +727,6 @@ static void state_tn_entry(void *obj)
 		LOG_ERR("lte_lc_system_mode_set, error: %d", err);
 
 		return;
-	}
-
-	/* Check if we are in offline-while-keeping-registration mode. If so, the modem has already
-	 * been able to register to a TN network, which means that the LTE link controller will
-	 * ignore +CEREG notifications with status 1 or 5. To work around this, we monitor the
-	 * +CEREG notifications in the application.
-	 */
-	if (initialized) {
-		LOG_DBG("Start monitoring incoming CEREG Notifications");
-		at_monitor_resume(&cereg_monitor);
 	}
 
 	/* Connect to network */

--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 002c75be46c98d55ae24652cdb1c2ebb5ff43d0e
+      revision: 2d607e644189fd91b80ec5b976d4efc556695350
       import: true


### PR DESCRIPTION
Use newly added PDN events for suspended and resumed PDN connection.
This allows us to remove the workaround with AT monitor.