### PR TITLE
modules: cloud: shell: Update shell commands and documentation

### DIFF
--- a/app/src/modules/button/button_shell.c
+++ b/app/src/modules/button/button_shell.c
@@ -23,7 +23,7 @@ static int cmd_button_press(const struct shell *sh, size_t argc, char **argv)
 
 	if (argc != 2) {
 		(void)shell_print(sh, "Invalid number of arguments (%d)", argc);
-		(void)shell_print(sh, "Usage: att_button_press <button_number>");
+		(void)shell_print(sh, "Usage: att_button press <button_number>");
 		return 1;
 	}
 
@@ -45,4 +45,15 @@ static int cmd_button_press(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_CMD_REGISTER(att_button_press, NULL, "Asset Tracker Template Button CMDs", cmd_button_press);
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmds,
+			       SHELL_CMD(press,
+					 NULL,
+					 "Simulate a button press. Usage: press <button_number>",
+					 cmd_button_press),
+			       SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(att_button,
+		   &sub_cmds,
+		   "Asset Tracker Template Button module commands",
+		   NULL);

--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(cloud, CONFIG_APP_CLOUD_LOG_LEVEL);
  * The cloud state machine does not support out of order provisioning via nRF Provisioning shell.
  */
 BUILD_ASSERT(!IS_ENABLED(CONFIG_NRF_PROVISIONING_SHELL),
-	     "nRF Provisioning Shell not supported, use att_cloud_provision shell command instead");
+	"nRF Provisioning Shell not supported, use 'att_cloud provision' shell command instead");
 
 BUILD_ASSERT(CONFIG_APP_CLOUD_WATCHDOG_TIMEOUT_SECONDS >
 	     CONFIG_APP_CLOUD_MSG_PROCESSING_TIMEOUT_SECONDS,

--- a/app/src/modules/cloud/cloud_shell.c
+++ b/app/src/modules/cloud/cloud_shell.c
@@ -31,7 +31,7 @@ static int cmd_publish(const struct shell *sh, size_t argc, char **argv)
 
 	if (argc != 3) {
 		(void)shell_print(sh, "Invalid number of arguments (%d)", argc);
-		(void)shell_print(sh, "Usage: att_cloud_publish <appid> <data>");
+		(void)shell_print(sh, "Usage: att_cloud publish <appid> <data>");
 		return 1;
 	}
 
@@ -101,17 +101,26 @@ static int cmd_provisioning(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(prov_sub_cmds,
-			       SHELL_CMD(now,
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmds,
+			       SHELL_CMD(publish,
 					 NULL,
-					 "Perform provisioning now",
+					 "Publish custom data message to cloud. "
+					 "Usage: publish <appid> <data>",
+					 cmd_publish),
+			       SHELL_CMD(provision,
+					 NULL,
+					 "Perform provisioning. The application will connect to the "
+					 "nRF Cloud provisioning service and check for pending commands",
 					 cmd_provisioning),
+			       SHELL_CMD(poll_shadow_delta,
+					 NULL,
+					 "Poll the device shadow delta to receive pending "
+					 "configuration updates",
+					 cmd_poll_shadow),
 			       SHELL_SUBCMD_SET_END
 );
 
-SHELL_CMD_REGISTER(att_cloud_publish, NULL, "Asset Tracker Template Cloud CMDs",
-		   cmd_publish);
-SHELL_CMD_REGISTER(att_cloud_provision, &prov_sub_cmds, "Asset Tracker Template Provisioning CMDs",
+SHELL_CMD_REGISTER(att_cloud,
+		   &sub_cmds,
+		   "Asset Tracker Template Cloud module commands",
 		   NULL);
-SHELL_CMD_REGISTER(att_cloud_poll_shadow_delta, NULL, "Poll the device shadow delta from the cloud",
-		   cmd_poll_shadow);

--- a/app/src/modules/network/network_shell.c
+++ b/app/src/modules/network/network_shell.c
@@ -63,4 +63,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmds,
 			       SHELL_SUBCMD_SET_END
 );
 
-SHELL_CMD_REGISTER(att_network, &sub_cmds, "Asset Tracker Template Network CMDs", NULL);
+SHELL_CMD_REGISTER(att_network,
+		   &sub_cmds,
+		   "Asset Tracker Template Network module commands",
+		   NULL);

--- a/app/src/modules/power/power_shell.c
+++ b/app/src/modules/power/power_shell.c
@@ -59,9 +59,13 @@ static int cmd_power_sample(const struct shell *shell, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_cmds,
-	SHELL_CMD(sample, NULL,
+	SHELL_CMD(sample,
+		  NULL,
 		  "Request a battery sample (state of charge, voltage, charging state)",
 		  cmd_power_sample),
 	SHELL_SUBCMD_SET_END);
 
-SHELL_CMD_REGISTER(att_power, &sub_cmds, "Asset Tracker Template Power CMDs", NULL);
+SHELL_CMD_REGISTER(att_power,
+		   &sub_cmds,
+		   "Asset Tracker Template Power module commands",
+		   NULL);

--- a/app/src/modules/storage/storage_shell.c
+++ b/app/src/modules/storage/storage_shell.c
@@ -155,7 +155,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(storage_mode_sub_cmds,
 	SHELL_SUBCMD_SET_END
 );
 
-SHELL_STATIC_SUBCMD_SET_CREATE(storage_sub_cmds,
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmds,
 	SHELL_CMD(flush, NULL, "Flush stored data", cmd_storage_flush),
 	SHELL_CMD(batch_request, NULL, "Request data from batch", cmd_storage_batch_request),
 	SHELL_CMD(clear, NULL, "Clear all stored data", cmd_storage_clear),
@@ -165,4 +165,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(storage_sub_cmds,
 	SHELL_SUBCMD_SET_END
 );
 
-SHELL_CMD_REGISTER(att_storage, &storage_sub_cmds, "Storage module commands", NULL);
+SHELL_CMD_REGISTER(att_storage,
+		   &sub_cmds,
+		   "Asset Tracker Template Storage module commands",
+		   NULL);

--- a/docs/common/provisioning.md
+++ b/docs/common/provisioning.md
@@ -107,7 +107,7 @@ To update device credentials:
 1. Select **Cloud Access Key Generation** and click **Create Command**.
 1. Trigger on device:
 
-   - **Shell**: `att_cloud_provision now`
+   - **Shell**: `att_cloud provision`
    - **Cloud**: Update device shadow with `{"desired": {"command": [1, 1]}}`.
 
 For detailed information on sending commands to devices through REST API, including command structure and available command types, see [Sending commands through REST API](configuration.md#sending-commands-through-rest-api) in the configuration documentation.

--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -53,13 +53,11 @@ uart:~$ help
 Available commands:
   app                          : Application version information commands
   at                           : Execute an AT command
-  att_button_press             : Asset Tracker Template Button CMDs
-  att_cloud_poll_shadow_delta  : Poll the device shadow delta from the cloud
-  att_cloud_provision          : Asset Tracker Template Provisioning CMDs
-  att_cloud_publish            : Asset Tracker Template Cloud CMDs
-  att_network                  : Asset Tracker Template Network CMDs
-  att_power                    : Asset Tracker Template Power CMDs
-  att_storage                  : Storage module commands
+  att_button                   : Asset Tracker Template Button module commands
+  att_cloud                    : Asset Tracker Template Cloud module commands
+  att_network                  : Asset Tracker Template Network module commands
+  att_power                    : Asset Tracker Template Power module commands
+  att_storage                  : Asset Tracker Template Storage module commands
   clear                        : Clear screen.
   date                         : Date commands
   device                       : Device commands
@@ -88,14 +86,14 @@ Available commands:
 #### Cloud Publishing
 
 ```bash
-uart:~$ att_cloud_publish TEMP "24"
+uart:~$ att_cloud publish TEMP "24"
 Sending on payload channel: {"messageType":"DATA","appId":"TEMP","data":"24","ts":1744359144653} (68 bytes)
 ```
 
 #### Perform cloud provisioning
 
 ```bash
-uart:~$ att_cloud_provision now
+uart:~$ att_cloud provision
 [00:00:42.258,361] <dbg> cloud: state_connected_ready_run: Provisioning request received
 [00:00:42.258,453] <dbg> cloud: state_connected_exit: state_connected_exit
 ...

--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -144,7 +144,7 @@ def run_fota_reschedule(dut_fota, fota_type):
     for i in range(3):
         try:
             time.sleep(30)
-            dut_fota.uart.write("att_button_press 1\r\n")
+            dut_fota.uart.write("att_button press 1\r\n")
             dut_fota.uart.wait_for_str("nrf_cloud_fota_poll: Starting FOTA download")
             break
         except AssertionError:
@@ -174,7 +174,7 @@ def run_fota_fixture(dut_fota, hex_file, reschedule=False):
         for i in range(3):
             try:
                 time.sleep(10)
-                dut_fota.uart.write("att_button_press 1\r\n")
+                dut_fota.uart.write("att_button press 1\r\n")
                 dut_fota.uart.wait_for_str("nrf_cloud_fota_poll: Starting FOTA download", timeout=30)
                 break
             except AssertionError:
@@ -236,7 +236,7 @@ def run_fota_fixture(dut_fota, hex_file, reschedule=False):
             for i in range(3):
                 try:
                     time.sleep(10)
-                    dut_fota.uart.write("att_button_press 1\r\n")
+                    dut_fota.uart.write("att_button press 1\r\n")
                     dut_fota.uart.wait_for_str("nrf_cloud_fota_poll: Starting FOTA download", timeout=30)
                     break
                 except AssertionError:

--- a/tests/on_target/tests/test_functional/test_shell.py
+++ b/tests/on_target/tests/test_functional/test_shell.py
@@ -45,12 +45,12 @@ def test_shell(dut_cloud, hex_file):
 
     # Button press
     dut_cloud.uart.flush()
-    dut_cloud.uart.write("att_button_press 1\r\n")
+    dut_cloud.uart.write("att_button press 1\r\n")
     dut_cloud.uart.wait_for_str(patterns_button_press, timeout=20)
 
     # Cloud publish
     dut_cloud.uart.flush()
-    dut_cloud.uart.write("att_cloud_publish donald duck\r\n")
+    dut_cloud.uart.write("att_cloud publish donald duck\r\n")
     dut_cloud.uart.wait_for_str(patterns_cloud_publish, timeout=20)
 
     messages = dut_cloud.cloud.get_messages(dut_cloud.device_id, appname="donald", max_records=20, max_age_hrs=0.25)

--- a/tests/on_target/tests/test_provisioning/test_provisioning.py
+++ b/tests/on_target/tests/test_provisioning/test_provisioning.py
@@ -219,7 +219,7 @@ def _trigger_device_reprovisioning_with_new_credentials(dut_cloud, sec_tag: int)
     # Simulate a button press to make the device check for new commands
     logger.info("Simulating button press to trigger command processing on device.")
 
-    dut_cloud.uart.write("att_button_press 1\r\n")
+    dut_cloud.uart.write("att_button press 1\r\n")
 
 
 def _trigger_device_reprovisioning_expecting_no_commands(dut_cloud):
@@ -243,7 +243,7 @@ def _trigger_device_reprovisioning_expecting_no_commands(dut_cloud):
     # Simulate a button press to make the device check for commands
     logger.info("Simulating button press to trigger command processing on device.")
 
-    dut_cloud.uart.write("att_button_press 1\r\n")
+    dut_cloud.uart.write("att_button press 1\r\n")
 
 
 # --- Test Phases ---


### PR DESCRIPTION
Combine the att cloud shell command into a single command with subcommands for better usability. Update the documentation accordingly to reflect the new command structure.

Align command structure among all shell commands offered by the template.