### PR TITLE
memfault: Pull in latest Memfault fixes in sdk-nrf

### DIFF
--- a/app/overlay-memfault.conf
+++ b/app/overlay-memfault.conf
@@ -20,7 +20,6 @@ CONFIG_MEMFAULT_COREDUMP_FULL_THREAD_STACKS=y
 ## Disable location metrics due to not being properly implemented for external handling of location
 ## requests when using the location library.
 CONFIG_MEMFAULT_NCS_LOCATION_METRICS=n
-CONFIG_MEMFAULT_NRF_PLATFORM_BATTERY_NPM13XX=y
 
 # Certificate management
 CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y

--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -949,19 +949,6 @@ static void state_connected_entry(void *obj)
 
 	LOG_DBG("%s", __func__);
 	LOG_INF("Connected to Cloud");
-
-#if defined(CONFIG_MEMFAULT)
-	if (memfault_coredump_has_valid_coredump(NULL)) {
-		/* Initial update to Memfault is handled internally in the
-		 * Memfault LTE coredump layer.
-		 */
-		return;
-	}
-
-	/* No coredump available, trigger an initial update to Memfault. */
-	(void)memfault_metrics_heartbeat_debug_trigger();
-	(void)memfault_zephyr_port_post_data();
-#endif /* CONFIG_MEMFAULT */
 }
 
 static void state_connected_exit(void *obj)

--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: a4367fdc0db21331df42b79fd16d5797b559f732
+      revision: 0d2caeecd6a850649d992885cd8e7994da91933c
       import: true


### PR DESCRIPTION
 - Initial upload of heartbeat data added to memfaulte lte coredump layer removing the need to have specific functionality in the app.
 - Battery data is automatically captured for Thingy:91 X devices, therefore its removed from the memfault overlay file in the app.