### PR TITLE
docs: tooling_troubleshooting: fix shell command formatting

### DIFF
--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -424,9 +424,9 @@ Screen capture from a coredump received in Memfault:
 Trigger test faults using shell commands:
 
 ```bash
-uart:~$ mflt_nrf test hardfault
-uart:~$ mflt_nrf test assert
-uart:~$ mflt_nrf test usagefault
+uart:~$ mflt test hardfault
+uart:~$ mflt test assert
+uart:~$ mflt test usagefault
 ```
 
 ## Modem Tracing


### PR DESCRIPTION
Correct memfault test commands in troubleshooting documentation.