### PR TITLE
modules: Move state objects off the static

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1948,7 +1948,7 @@ int main(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct main_state main_state = { 0 };
+	static struct main_state main_state;
 
 	main_state.sample_interval_sec = CONFIG_APP_BUFFER_MODE_SAMPLING_INTERVAL_SECONDS;
 	main_state.update_interval_sec = CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS;

--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -1149,7 +1149,7 @@ static void cloud_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_CLOUD_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct cloud_state_object cloud_state = { 0 };
+	static struct cloud_state_object cloud_state;
 
 	LOG_DBG("Cloud module task started");
 

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -170,7 +170,7 @@ static void env_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_ENVIRONMENTAL_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct environmental_state_object environmental_state = {
+	static struct environmental_state_object environmental_state = {
 		.bme680 = DEVICE_DT_GET(DT_NODELABEL(bme680)),
 	};
 

--- a/app/src/modules/fota/fota.c
+++ b/app/src/modules/fota/fota.c
@@ -514,7 +514,7 @@ static void fota_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_FOTA_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct fota_state_object fota_state = {
+	static struct fota_state_object fota_state = {
 		.fota_ctx.reboot_fn = fota_reboot,
 		.fota_ctx.status_fn = fota_status,
 	};

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -556,7 +556,7 @@ static void location_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_LOCATION_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct location_state_object location_state = { 0 };
+	static struct location_state_object location_state;
 
 	LOG_DBG("Location module task started");
 

--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -593,7 +593,7 @@ static void network_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_NETWORK_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct network_state_object network_state;
+	static struct network_state_object network_state;
 
 	task_wdt_id = task_wdt_add(wdt_timeout_ms, network_wdt_callback, (void *)k_current_get());
 	if (task_wdt_id < 0) {

--- a/app/src/modules/power/power.c
+++ b/app/src/modules/power/power.c
@@ -469,7 +469,7 @@ static void power_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_POWER_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct power_state_object power_state;
+	static struct power_state_object power_state;
 
 	LOG_DBG("Power module task started");
 

--- a/app/src/modules/storage/storage.c
+++ b/app/src/modules/storage/storage.c
@@ -1056,7 +1056,7 @@ static void storage_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_STORAGE_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	struct storage_state storage_state = {0};
+	static struct storage_state storage_state;
 
 	LOG_DBG("Storage module task started");
 


### PR DESCRIPTION
Make the state objects static, thereby moving them off the stack while keeping the scope the same.