### PR TITLE
src: modules: Reduce stack sizes

### DIFF
--- a/app/src/modules/cloud/Kconfig.cloud
+++ b/app/src/modules/cloud/Kconfig.cloud
@@ -82,7 +82,7 @@ config APP_CLOUD_BACKOFF_MAX_SECONDS
 
 config APP_CLOUD_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 8192
+	default 4096
 
 config APP_CLOUD_MESSAGE_QUEUE_SIZE
 	int "Message queue size"

--- a/app/src/modules/environmental/Kconfig.environmental
+++ b/app/src/modules/environmental/Kconfig.environmental
@@ -13,7 +13,7 @@ if APP_ENVIRONMENTAL
 
 config APP_ENVIRONMENTAL_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 1024
+	default 512
 
 config APP_ENVIRONMENTAL_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout"

--- a/app/src/modules/fota/Kconfig.fota
+++ b/app/src/modules/fota/Kconfig.fota
@@ -12,7 +12,7 @@ if APP_FOTA
 
 config APP_FOTA_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 2500
+	default 2048
 
 config APP_FOTA_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout"

--- a/app/src/modules/location/Kconfig.location
+++ b/app/src/modules/location/Kconfig.location
@@ -12,7 +12,7 @@ if APP_LOCATION
 
 config APP_LOCATION_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 4096
+	default 2048
 
 config APP_LOCATION_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout"

--- a/app/src/modules/network/Kconfig.network
+++ b/app/src/modules/network/Kconfig.network
@@ -15,7 +15,7 @@ config APP_NETWORK_SHELL
 
 config APP_NETWORK_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 2048
+	default 1024
 
 config APP_NETWORK_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout"

--- a/app/src/modules/storage/Kconfig.storage
+++ b/app/src/modules/storage/Kconfig.storage
@@ -12,7 +12,7 @@ if APP_STORAGE
 
 config APP_STORAGE_THREAD_STACK_SIZE
 	int "Storage module thread stack size"
-	default 2048
+	default 1024
 
 config APP_STORAGE_BACKEND_RAM
 	bool "RAM storage backend"

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -222,7 +222,7 @@ The following includes the key configuration categories:
 
 ### Thread Configuration
 
-- **`CONFIG_APP_STORAGE_THREAD_STACK_SIZE`** (default: 1536): Stack size for the storage module's main thread.
+- **`CONFIG_APP_STORAGE_THREAD_STACK_SIZE`** (default: 1024): Stack size for the storage module's main thread.
 
 - **`CONFIG_APP_STORAGE_WATCHDOG_TIMEOUT_SECONDS`** (default: 60): Watchdog timeout for detecting stuck operations.
 


### PR DESCRIPTION
State variables were moved off the stacks in a previous commmit. Reduce the stack sizes accordingly to make the debug build for the t91x pass in ci.