### PR TITLE
manifest: Pull in fix for BMM350 initialization

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 3653fec21b6a44d996217a37d3093ffe42b09160
+      revision: e14966575fe9552bd6c8c47133eb7af5e7499ed1
       import: true


### PR DESCRIPTION
Updates the sdk-nrf revision to include a fix for BMM350