### PR TITLE
tests: Use non-debug build for power test

### DIFF
--- a/tests/on_target/tests/test_ppk/test_power.py
+++ b/tests/on_target/tests/test_ppk/test_power.py
@@ -215,13 +215,13 @@ def thingy91x_ppk2():
     ppk2_dev.toggle_DUT_power("OFF")
 
 @pytest.mark.slow
-def test_power(thingy91x_ppk2, debug_hex_file):
+def test_power(thingy91x_ppk2, hex_file):
     '''
     Test that the device can reach PSM and measure the current consumption
 
     Current consumption is measured and report generated.
     '''
-    flash_device(os.path.abspath(debug_hex_file), serial=SEGGER)
+    flash_device(os.path.abspath(hex_file), serial=SEGGER)
     reset_device(serial=SEGGER)
     try:
         thingy91x_ppk2.t91x_uart.wait_for_str("Connected to Cloud", timeout=120)


### PR DESCRIPTION
There is an unsolved issue with power consumption then ETB is enabled. The power tests will always fail if ETB is used, so revert to using normal build for power test.