### PR TITLE
modules: network: Add handling of LTE_LC_MODEM_EVT_SEARCH_DONE

### DIFF
--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -220,6 +220,9 @@ static void lte_lc_evt_handler(const struct lte_lc_evt *const evt)
 		} else if (evt->modem_evt.type == LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE) {
 			LOG_DBG("LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE");
 			network_status_notify(NETWORK_LIGHT_SEARCH_DONE);
+		} else if (evt->modem_evt.type == LTE_LC_MODEM_EVT_SEARCH_DONE) {
+			LOG_DBG("LTE_LC_MODEM_EVT_SEARCH_DONE");
+			network_status_notify(NETWORK_SEARCH_DONE);
 		}
 		break;
 	case LTE_LC_EVT_PSM_UPDATE: {

--- a/app/src/modules/network/network.h
+++ b/app/src/modules/network/network.h
@@ -46,6 +46,13 @@ enum network_msg_type {
 	 */
 	NETWORK_LIGHT_SEARCH_DONE,
 
+	/* The modem has completed a full search for a network to attach to without finding a
+	 * suitable cell according to 3GPP selection rules.
+	 * The modem will continue to search periodically for a suitable cell if it left in
+	 * normal mode.
+	 */
+	NETWORK_SEARCH_DONE,
+
 	/* A network attach request has been rejected by the network. */
 	NETWORK_ATTACH_REJECTED,
 

--- a/tests/module/network/src/main.c
+++ b/tests/module/network/src/main.c
@@ -367,6 +367,17 @@ void test_light_search_done(void)
 	TEST_ASSERT_EQUAL(NETWORK_LIGHT_SEARCH_DONE, msg.type);
 }
 
+void test_search_done(void)
+{
+	struct network_msg msg;
+
+	send_mdmev_evt(LTE_LC_MODEM_EVT_SEARCH_DONE);
+
+	wait_for_and_check_msg(&msg, NETWORK_SEARCH_DONE);
+
+	TEST_ASSERT_EQUAL(NETWORK_SEARCH_DONE, msg.type);
+}
+
 void test_modem_reset_loop(void)
 {
 	struct network_msg msg;


### PR DESCRIPTION
Add handling of LTE_LC_MODEM_EVT_SEARCH_DONE and let the network module send it as NETWORK_SEARCH_DONE on its zbus channel.

The message type is not used by the application, only made available.