### PR TITLE
network: Treewide fix after connection manager removal

### DIFF
--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -118,7 +118,7 @@ and execute them if any. You can use it to reprovision the device for developmen
 uart:~$ att_network disconnect
 [00:00:36.758,758] <dbg> network: state_disconnecting_entry: state_disconnecting_entry
 [00:00:37.196,746] <wrn> network: Not registered, check rejection cause
-[00:00:37.197,021] <dbg> network: l4_event_handler: Network connectivity lost
+[00:00:37.197,021] <dbg> network: lte_lc_evt_handler: PDN connection network detached
 [00:00:37.198,608] <dbg> cloud: state_connected_paused_entry: state_connected_paused_entry
 [00:00:37.198,974] <dbg> main: wait_for_trigger_exit: wait_for_trigger_exit
 [00:00:37.199,005] <dbg> main: idle_entry: idle_entry

--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -63,7 +63,7 @@ def get_modemversion(dut_fota):
 
 def perform_disconnect_reconnect(dut_fota, expected_percentage):
     """Helper function to perform a disconnect/reconnect sequence and verify resumption at expected percentage"""
-    patterns_lte_offline = ["network: l4_event_handler: Network connectivity lost"]
+    patterns_lte_offline = ["network: lte_lc_evt_handler: PDN connection network detached"]
     patterns_lte_normal = ["network: l4_event_handler: Network connectivity established"]
 
     logger.info(f"Disconnecting at {expected_percentage}% - device should resume at same percentage")

--- a/tests/on_target/tests/test_functional/test_shell.py
+++ b/tests/on_target/tests/test_functional/test_shell.py
@@ -31,7 +31,7 @@ def test_shell(dut_cloud, hex_file):
         'Sending on payload channel: {"messageType":"DATA","appId":"donald","data":"duck"',
     ]
     patterns_network_disconnected = [
-        "network: l4_event_handler: Network connectivity lost",
+        "network: lte_lc_evt_handler: PDN connection network detached",
     ]
     patterns_network_connected = [
         "network: l4_event_handler: Network connectivity established",

--- a/tests/on_target/tests/test_provisioning/test_provisioning.py
+++ b/tests/on_target/tests/test_provisioning/test_provisioning.py
@@ -44,7 +44,7 @@ def _wait_for_lte_connection(dut_cloud, timeout: int = 240):
 def _disconnect_network_and_clear_modem_credentials(dut_cloud, sec_tag: int):
     logger.info("Disconnecting network and clearing modem credentials...")
 
-    log_pattern_network_disconnected = "network: l4_event_handler: Network connectivity lost"
+    log_pattern_network_disconnected = "network: lte_lc_evt_handler: PDN connection network detached"
     dut_cloud.uart.write("att_network disconnect\r\n")
     dut_cloud.uart.wait_for_str(
         log_pattern_network_disconnected,


### PR DESCRIPTION
Update occurrences of connection manager references treewide.