### PR TITLE
app: Re-introduce networking configurations

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -40,6 +40,10 @@ CONFIG_LTE_LC_PSM_MODULE=y
 CONFIG_LTE_LC_EDRX_MODULE=y
 CONFIG_LTE_LC_CONN_EVAL_MODULE=y
 
+# Modem library shared memory buffers - 4KB is sufficient for this application
+CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE=4096
+CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE=4096
+
 # Enable PSM (Power Saving Mode)
 CONFIG_LTE_LC_WORKQUEUE_STACK_SIZE=896
 CONFIG_LTE_PSM_REQ=y
@@ -178,22 +182,26 @@ CONFIG_NET_IPV6=n
 CONFIG_NET_NATIVE=y
 CONFIG_NET_DHCPV4=n
 
-# Network buffers and packets (need enough for concurrent WiFi scan + CoAP)
+# Network buffers and packets (restore original values before conn mgr removal)
 CONFIG_NET_BUF_RX_COUNT=8
 CONFIG_NET_BUF_TX_COUNT=8
-CONFIG_NET_PKT_RX_COUNT=4
-CONFIG_NET_PKT_TX_COUNT=4
+# Keep at 1 - original value that worked before
+CONFIG_NET_PKT_RX_COUNT=1
+CONFIG_NET_PKT_TX_COUNT=1
 
-# Network thread stack sizes (need headroom for CoAP/DTLS processing)
-CONFIG_NET_TX_STACK_SIZE=1024
-CONFIG_NET_RX_STACK_SIZE=1024
+# Network thread stack sizes (restore original values)
+CONFIG_NET_TX_STACK_SIZE=512
+CONFIG_NET_RX_STACK_SIZE=512
 CONFIG_NET_MGMT_EVENT_STACK_SIZE=1280
 
-# Network resources (multiple contexts needed for CoAP + WiFi operations)
+# Network resources (same as before connection manager removal)
 CONFIG_NET_TC_TX_COUNT=1
-CONFIG_NET_MAX_CONTEXTS=5
-CONFIG_NET_MAX_CONN=4
+CONFIG_NET_MAX_CONTEXTS=3
+CONFIG_NET_MAX_CONN=2
 CONFIG_NET_IF_MAX_IPV4_COUNT=2
+
+# Reduce Memfault logging buffer for debug builds to fit in RAM
+CONFIG_MEMFAULT_LOGGING_RAM_SIZE=3584
 
 # For debugging purposes
 CONFIG_THREAD_NAME=y


### PR DESCRIPTION
Some configurations got higher defaults when they were removed as part of connection manager removal.
Re-introducing them reduces total RAM footprint.