### PR TITLE
power: Add fuel gauge state persistence to no-init RAM

### DIFF
--- a/app/src/modules/power/CMakeLists.txt
+++ b/app/src/modules/power/CMakeLists.txt
@@ -5,5 +5,6 @@
 #
 
 target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/power.c)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/fuel_gauge_state.c)
 target_sources_ifdef(CONFIG_APP_POWER_SHELL app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/power_shell.c)
 target_include_directories(app PRIVATE .)

--- a/app/src/modules/power/fuel_gauge_state.c
+++ b/app/src/modules/power/fuel_gauge_state.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <nrf_fuel_gauge.h>
+#include <errno.h>
+
+#include "fuel_gauge_state.h"
+
+LOG_MODULE_DECLARE(power, CONFIG_APP_POWER_LOG_LEVEL);
+
+#define FUEL_GAUGE_MAGIC 0x4647534F /* "FGSO" - Fuel Gauge State OK */
+
+struct fuel_gauge_state {
+	uint32_t magic;     /* Magic number to identify valid state */
+	uint32_t size;      /* Size of state data */
+	uint8_t state[256]; /* Fuel gauge state buffer */
+};
+
+/* Place the fuel gauge state in the noinit RAM section.
+ * This ensures the data persists across warm resets.
+ */
+static __noinit struct fuel_gauge_state fuel_gauge_noinit;
+
+static bool fuel_gauge_state_is_valid(void)
+{
+	if (fuel_gauge_noinit.magic != FUEL_GAUGE_MAGIC) {
+		LOG_DBG("No valid fuel gauge state found (magic: 0x%08x)",
+			fuel_gauge_noinit.magic);
+		return false;
+	}
+
+	if ((fuel_gauge_noinit.size == 0) ||
+	    (fuel_gauge_noinit.size > sizeof(fuel_gauge_noinit.state))) {
+		LOG_WRN("Invalid fuel gauge state size: %u", fuel_gauge_noinit.size);
+		return false;
+	}
+
+	return true;
+}
+
+int fuel_gauge_state_save(void)
+{
+	int err;
+	size_t state_size = nrf_fuel_gauge_state_size;
+
+	if (state_size > sizeof(fuel_gauge_noinit.state)) {
+		LOG_ERR("Fuel gauge state size too large: %zu", state_size);
+		return -ENOMEM;
+	}
+
+	err = nrf_fuel_gauge_state_get(fuel_gauge_noinit.state, state_size);
+	if (err) {
+		LOG_ERR("nrf_fuel_gauge_state_get failed: %d", err);
+		return err;
+	}
+
+	fuel_gauge_noinit.size = state_size;
+	fuel_gauge_noinit.magic = FUEL_GAUGE_MAGIC;
+
+	LOG_DBG("Saved fuel gauge state to no-init RAM (%zu bytes)", state_size);
+	return 0;
+}
+
+const void *fuel_gauge_state_get(void)
+{
+	if (!fuel_gauge_state_is_valid()) {
+		return NULL;
+	}
+
+	return fuel_gauge_noinit.state;
+}
+
+size_t fuel_gauge_state_size_get(void)
+{
+	if (!fuel_gauge_state_is_valid()) {
+		return 0;
+	}
+
+	return fuel_gauge_noinit.size;
+}

--- a/app/src/modules/power/fuel_gauge_state.h
+++ b/app/src/modules/power/fuel_gauge_state.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef _FUEL_GAUGE_STATE_H_
+#define _FUEL_GAUGE_STATE_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Save the current fuel gauge state to no-init RAM.
+ *
+ * Retrieves the current state from the nRF Fuel Gauge library and stores it
+ * in a no-init RAM section. This allows the state to persist across warm resets.
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int fuel_gauge_state_save(void);
+
+/**
+ * @brief Get pointer to saved fuel gauge state.
+ *
+ * Returns a pointer to the saved fuel gauge state buffer if valid state exists.
+ * The state is considered valid if the magic number matches and the size is within bounds.
+ *
+ * @return Pointer to state buffer on success, NULL if no valid state exists
+ */
+const void *fuel_gauge_state_get(void);
+
+/**
+ * @brief Get size of saved fuel gauge state.
+ *
+ * @return Size of saved state in bytes, or 0 if no valid state exists
+ */
+size_t fuel_gauge_state_size_get(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FUEL_GAUGE_STATE_H_ */

--- a/tests/module/power/CMakeLists.txt
+++ b/tests/module/power/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(app
   src/power_module_test.c
   src/redef.c
   ${ASSET_TRACKER_TEMPLATE_DIR}/app/src/modules/power/power.c
+  ${ASSET_TRACKER_TEMPLATE_DIR}/app/src/modules/power/fuel_gauge_state.c
 )
 
 target_include_directories(app PRIVATE src)


### PR DESCRIPTION
After reboot, the fuel gauge re-initialized from scratch, causing
inaccurate SOC readings that takes 10-15 minutes to converge.

Store fuel gauge state in no-init RAM section to persist across
reboots. State is automatically saved after each query and restored
on boot, ensuring accurate battery readings immediately after reboot.

[x] Verify behavior
[x] Tests
[] Documentation
[x] Refactor, new functions can be placed into separate .c/.h header files