### PR TITLE
prj.conf: Set TFM minimal profile

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -14,6 +14,10 @@ CONFIG_DK_LIBRARY=y
 CONFIG_ZVFS_OPEN_MAX=20
 CONFIG_PWM=y
 
+# TF-M config - Most of the crypto operations are offloaded to the modem,
+# minimal profile is sufficient.
+CONFIG_TFM_PROFILE_TYPE_MINIMAL=y
+
 # TFM logging over uart0
 CONFIG_TFM_LOG_LEVEL_SILENCE=n
 CONFIG_TFM_SECURE_UART0=y


### PR DESCRIPTION
TFM minial profile is no longer default for nRF9151DK so we need to explicitly set it in the app configuration.