### PR TITLE
tests: on_target: Don't expect storage of NETWORK data

### DIFF
--- a/tests/on_target/tests/test_functional/test_buffer_flash.py
+++ b/tests/on_target/tests/test_functional/test_buffer_flash.py
@@ -56,8 +56,7 @@ def test_buffer_flash(dut_cloud, hex_file_buffer_flash):
     header_list = [
         get_header_str("LOCATION"),
         get_header_str("BATTERY"),
-        get_header_str("ENVIRONMENTAL"),
-        get_header_str("NETWORK")
+        get_header_str("ENVIRONMENTAL")
     ]
 
     storage_full_list = [

--- a/tests/on_target/tests/test_functional/test_buffer_ram.py
+++ b/tests/on_target/tests/test_functional/test_buffer_ram.py
@@ -49,8 +49,7 @@ def test_buffer_ram(dut_cloud, hex_file_buffer_ram):
         initialization_list = [
                 get_initialized_str("BATTERY"),
                 get_initialized_str("ENVIRONMENTAL"),
-                get_initialized_str("LOCATION"),
-                get_initialized_str("NETWORK")
+                get_initialized_str("LOCATION")
         ]
 
         storing_list = [


### PR DESCRIPTION
Storing of NETWORK data has been removed in a previous commit. Update the end-to-end test to reflect this change.