### PR TITLE
network: Add missing break in switch statement

### DIFF
--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -191,6 +191,7 @@ static void lte_lc_evt_handler(const struct lte_lc_evt *const evt)
 			LOG_DBG("PDN connection resumed");
 			network_status_notify(NETWORK_CONNECTED);
 
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
Add missing break to LTE_LC_EVT_PDN_RESUMED case.