### PR TITLE
workflows: Remove `pmr-*-buffer-*` test assets before release

### DIFF
--- a/.github/workflows/attach_release_assets.yml
+++ b/.github/workflows/attach_release_assets.yml
@@ -36,6 +36,7 @@ jobs:
         - name: Delete test assets
           run: |
             rm -f asset-tracker-template-*-buffer-flash-* asset-tracker-template-*-buffer-ram-*
+            rm -f pmr-*-buffer-flash* pmr-*-buffer-ram*
 
         - name: Deploy release to github
           uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Delete `pmr-*-buffer-flash*` and `pmr-*-buffer-ram*` files alongside the existing `asset-tracker-template-*-buffer-*` cleanup step to prevent test artifacts from being attached to the release.