### PR TITLE
app: Unify zbus publish timeouts

### DIFF
--- a/app/src/common/app_common.h
+++ b/app/src/common/app_common.h
@@ -50,6 +50,9 @@ extern "C" {
 #define MAX_MSG_SIZE_FROM_LIST(_CHAN_LIST) \
         sizeof(union {_CHAN_LIST(UNION_MEMBER)})
 
+/* Timeout for zbus channel publishing */
+#define PUB_TIMEOUT K_MSEC(100)
+
 #ifdef __cplusplus
 }
 #endif

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -38,9 +38,6 @@
 /* Register log module */
 LOG_MODULE_REGISTER(main, 4);
 
-/* Configuration constants to replace magic numbers */
-#define ZBUS_PUBLISH_TIMEOUT_MS		100
-
 /* Register subscriber */
 ZBUS_MSG_SUBSCRIBER_DEFINE(main_subscriber);
 
@@ -371,7 +368,7 @@ static void poll_shadow_send(enum cloud_msg_type type)
 		return;
 	}
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish cloud shadow poll trigger, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -385,7 +382,7 @@ static void poll_triggers_send(void)
 	int err;
 	enum fota_msg_type fota_msg = FOTA_POLL_REQUEST;
 
-	err = zbus_chan_pub(&FOTA_CHAN, &fota_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&FOTA_CHAN, &fota_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish FOTA poll trigger, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -433,7 +430,7 @@ static void sampling_begin_common(struct main_state *state_object,
 		.repetitions = 10,
 	};
 
-	err = zbus_chan_pub(&LED_CHAN, &led_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&LED_CHAN, &led_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish LED pattern message, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -444,8 +441,7 @@ static void sampling_begin_common(struct main_state *state_object,
 
 	state_object->sample_start_time = k_uptime_seconds();
 
-	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg,
-			    K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish location search trigger, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -510,7 +506,7 @@ static void sensor_triggers_send(void)
 		.type = POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST,
 	};
 
-	err = zbus_chan_pub(&POWER_CHAN, &power_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&POWER_CHAN, &power_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish power battery sample request, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -524,8 +520,7 @@ static void sensor_triggers_send(void)
 		.type = ENVIRONMENTAL_SENSOR_SAMPLE_REQUEST,
 	};
 
-	err = zbus_chan_pub(&ENVIRONMENTAL_CHAN, &environmental_msg,
-			    K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&ENVIRONMENTAL_CHAN, &environmental_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish environmental sensor sample request, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -545,7 +540,7 @@ static void storage_send_data(struct main_state *state_object)
 	state_object->storage_session_id = k_uptime_get_32();
 	storage_msg.session_id = state_object->storage_session_id;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &storage_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&STORAGE_CHAN, &storage_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish storage batch request (session: %u), error: %d",
 			storage_msg.session_id, err);
@@ -576,7 +571,7 @@ static void cloud_send_now(struct main_state *state_object)
 		.repetitions = 10,
 	};
 
-	err = zbus_chan_pub(&LED_CHAN, &led_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&LED_CHAN, &led_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish LED pattern message, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -594,7 +589,7 @@ static void timer_send_data_work_fn(struct k_work *work)
 
 	ARG_UNUSED(work);
 
-	err = zbus_chan_pub(&TIMER_CHAN, &msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&TIMER_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish cloud timer expired message, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -610,7 +605,7 @@ static void timer_sample_data_work_fn(struct k_work *work)
 
 	ARG_UNUSED(work);
 
-	err = zbus_chan_pub(&TIMER_CHAN, &msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&TIMER_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish sample data timer expired message, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -688,7 +683,7 @@ static void update_shadow_reported_section(const struct config_params *config,
 
 	cloud_msg.payload.buffer_data_len = encoded_len;
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish config report, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -737,7 +732,7 @@ static void config_apply(struct main_state *state_object, const struct config_pa
 		LOG_DBG("Updating storage threshold to %d samples", config->storage_threshold);
 		state_object->storage_threshold = config->storage_threshold;
 
-		err = zbus_chan_pub(&STORAGE_CHAN, &storage_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+		err = zbus_chan_pub(&STORAGE_CHAN, &storage_msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("Failed to publish storage threshold update, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -753,7 +748,7 @@ static void config_apply(struct main_state *state_object, const struct config_pa
 		/* Reset sample start time so re-entering waiting state uses full new interval */
 		state_object->sample_start_time = k_uptime_seconds();
 
-		err = zbus_chan_pub(&TIMER_CHAN, &timer_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+		err = zbus_chan_pub(&TIMER_CHAN, &timer_msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("Failed to publish timer config changed event, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -770,7 +765,7 @@ static void command_execute(uint32_t command_type)
 		struct cloud_msg cloud_msg = {
 			.type = CLOUD_PROVISIONING_REQUEST,
 		};
-		int err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+		int err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 
 		if (err) {
 			LOG_ERR("zbus_chan_pub, error: %d", err);
@@ -944,7 +939,7 @@ static void connected_entry(void *o)
 		int err;
 		enum fota_msg_type fota_msg = FOTA_POLL_REQUEST;
 
-		err = zbus_chan_pub(&FOTA_CHAN, &fota_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+		err = zbus_chan_pub(&FOTA_CHAN, &fota_msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("Failed to trigger FOTA polling on cloud connection: %d", err);
 		}
@@ -1067,7 +1062,7 @@ static void disconnected_waiting_entry(void *o)
 		.repetitions = 10,
 	};
 
-	err = zbus_chan_pub(&LED_CHAN, &led_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&LED_CHAN, &led_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish LED pattern, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1327,7 +1322,7 @@ static void fota_entry(void *o)
 		.repetitions = -1,
 	};
 
-	err = zbus_chan_pub(&LED_CHAN, &led_msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&LED_CHAN, &led_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish LED FOTA download pattern, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1448,7 +1443,7 @@ static void fota_waiting_for_network_disconnect_entry(void *o)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&NETWORK_CHAN, &msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&NETWORK_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish network disconnect request, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1487,7 +1482,7 @@ static void fota_waiting_for_network_disconnect_to_apply_image_entry(void *o)
 		.type = NETWORK_DISCONNECT
 	};
 
-	err = zbus_chan_pub(&NETWORK_CHAN, &msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&NETWORK_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish network disconnect request, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1528,7 +1523,7 @@ static void fota_applying_image_entry(void *o)
 	int err;
 	enum fota_msg_type msg = FOTA_IMAGE_APPLY;
 
-	err = zbus_chan_pub(&FOTA_CHAN, &msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&FOTA_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish FOTA image apply request, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1566,7 +1561,7 @@ static void fota_rebooting_entry(void *o)
 	LOG_DBG("%s", __func__);
 
 	/* Tell storage module to clear any stored data */
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_MSEC(ZBUS_PUBLISH_TIMEOUT_MS));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish storage clear message, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/button/button.c
+++ b/app/src/modules/button/button.c
@@ -49,7 +49,7 @@ static void long_press_work_handler(struct k_work *work)
 		msg.button_number = 1;
 		msg.type = BUTTON_PRESS_LONG;
 
-		err = zbus_chan_pub(&BUTTON_CHAN, &msg, K_SECONDS(1));
+		err = zbus_chan_pub(&BUTTON_CHAN, &msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("zbus_chan_pub long press, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -68,7 +68,7 @@ static void publish_short_press(uint8_t button_number)
 
 	LOG_DBG("Button %d short press", button_number);
 
-	err = zbus_chan_pub(&BUTTON_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&BUTTON_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub short press, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/button/button_shell.c
+++ b/app/src/modules/button/button_shell.c
@@ -9,6 +9,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/logging/log.h>
 
+#include "app_common.h"
 #include "button.h"
 
 LOG_MODULE_DECLARE(button, CONFIG_APP_BUTTON_LOG_LEVEL);
@@ -36,7 +37,7 @@ static int cmd_button_short(const struct shell *sh, size_t argc, char **argv)
 
 	msg.button_number = button_number;
 
-	err = zbus_chan_pub(&BUTTON_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&BUTTON_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;
@@ -68,7 +69,7 @@ static int cmd_button_long(const struct shell *sh, size_t argc, char **argv)
 
 	msg.button_number = button_number;
 
-	err = zbus_chan_pub(&BUTTON_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&BUTTON_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;

--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -23,6 +23,7 @@
 #include <memfault/panics/coredump.h>
 #endif /* CONFIG_MEMFAULT */
 
+#include "app_common.h"
 #include "cloud.h"
 #include "cloud_internal.h"
 #include "cloud_configuration.h"
@@ -280,7 +281,7 @@ static void connect_to_cloud(const struct cloud_state_object *state_object)
 		msg = CLOUD_CONNECTION_FAILED;
 	}
 
-	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -314,7 +315,7 @@ static void backoff_timer_work_fn(struct k_work *work)
 
 	ARG_UNUSED(work);
 
-	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -326,7 +327,7 @@ static void send_request_failed(void)
 	int err;
 	enum priv_cloud_msg cloud_msg = CLOUD_SEND_REQUEST_FAILED;
 
-	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -497,7 +498,7 @@ static int request_storage_batch_data(uint32_t session_id)
 
 	LOG_DBG("Requesting storage batch data, session_id: 0x%X", msg.session_id);
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to request storage batch data, error: %d", err);
 
@@ -569,7 +570,7 @@ static void handle_storage_batch_available(const struct storage_msg *msg)
 	}
 
 	/* Close the batch session */
-	err = zbus_chan_pub(&STORAGE_CHAN, &close_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &close_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to close storage batch session, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -586,7 +587,7 @@ static void handle_storage_batch_empty(const struct storage_msg *msg)
 
 	LOG_DBG("Storage batch is empty, closing session");
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &close_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &close_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to close empty storage batch session, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -603,7 +604,7 @@ static void handle_storage_batch_error(const struct storage_msg *msg)
 
 	LOG_ERR("Storage batch error occurred, closing session");
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &close_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &close_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to close error storage batch session, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -787,7 +788,7 @@ static void state_disconnected_entry(void *obj)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -896,7 +897,7 @@ static void state_connecting_provisioning_entry(void *obj)
 	/* Cancel any ongoing location search during provisioning to allow writing credentials,
 	 * which requires offline LTE functional mode.
 	 */
-	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1030,7 +1031,7 @@ static void state_connected_exit(void *obj)
 		SEND_FATAL_ERROR();
 	}
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1050,7 +1051,7 @@ static void state_connected_ready_entry(void *obj)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1133,7 +1134,7 @@ static void state_connected_paused_entry(void *obj)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/cloud/cloud_configuration.c
+++ b/app/src/modules/cloud/cloud_configuration.c
@@ -11,6 +11,7 @@
 #include <net/nrf_cloud_coap.h>
 #include <nrf_cloud_coap_transport.h>
 
+#include "app_common.h"
 #include "cloud.h"
 #include "cloud_configuration.h"
 #include "cloud_internal.h"
@@ -56,7 +57,7 @@ int cloud_configuration_poll(enum shadow_poll_type type)
 		return -ENODATA;
 	}
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		return err;

--- a/app/src/modules/cloud/cloud_location.c
+++ b/app/src/modules/cloud/cloud_location.c
@@ -131,7 +131,7 @@ static void send_request_failed(void)
 	int err;
 	enum priv_cloud_msg cloud_msg = CLOUD_SEND_REQUEST_FAILED;
 
-	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &cloud_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &cloud_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/cloud/cloud_provisioning.c
+++ b/app/src/modules/cloud/cloud_provisioning.c
@@ -28,7 +28,7 @@ static void nrf_provisioning_callback(const struct nrf_provisioning_callback_dat
 
 		nw_msg = NETWORK_DISCONNECT;
 
-		err = zbus_chan_pub(&NETWORK_CHAN, &nw_msg, K_SECONDS(1));
+		err = zbus_chan_pub(&NETWORK_CHAN, &nw_msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("zbus_chan_pub, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -40,7 +40,7 @@ static void nrf_provisioning_callback(const struct nrf_provisioning_callback_dat
 
 		nw_msg = NETWORK_CONNECT;
 
-		err = zbus_chan_pub(&NETWORK_CHAN, &nw_msg, K_SECONDS(1));
+		err = zbus_chan_pub(&NETWORK_CHAN, &nw_msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("zbus_chan_pub, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -122,7 +122,7 @@ static void nrf_provisioning_callback(const struct nrf_provisioning_callback_dat
 		return;
 	}
 
-	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/cloud/cloud_shell.c
+++ b/app/src/modules/cloud/cloud_shell.c
@@ -11,6 +11,7 @@
 #include <net/nrf_cloud_defs.h>
 #include <date_time.h>
 
+#include "app_common.h"
 #include "cloud.h"
 
 LOG_MODULE_DECLARE(cloud, CONFIG_APP_CLOUD_LOG_LEVEL);
@@ -54,7 +55,7 @@ static int cmd_publish(const struct shell *sh, size_t argc, char **argv)
 	(void)shell_print(sh, "Sending on payload channel: %s (%d bytes)",
 			  msg.payload.buffer, msg.payload.buffer_data_len);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;
@@ -73,7 +74,7 @@ static int cmd_poll_shadow(const struct shell *sh, size_t argc, char **argv)
 		.type = CLOUD_SHADOW_GET_DELTA,
 	};
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;
@@ -92,7 +93,7 @@ static int cmd_provisioning(const struct shell *sh, size_t argc, char **argv)
 		.type = CLOUD_PROVISIONING_REQUEST,
 	};
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&CLOUD_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -132,7 +132,7 @@ static void sample_sensors(const struct device *const bme680)
 	LOG_DBG("Temperature: %.2f C, Pressure: %.2f Pa, Humidity: %.2f %%",
 		msg.temperature, msg.pressure, msg.humidity);
 
-	err = zbus_chan_pub(&ENVIRONMENTAL_CHAN, &msg, K_NO_WAIT);
+	err = zbus_chan_pub(&ENVIRONMENTAL_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/fota/fota.c
+++ b/app/src/modules/fota/fota.c
@@ -225,7 +225,7 @@ static void fota_reboot(enum nrf_cloud_fota_reboot_status status)
 
 	LOG_DBG("Reboot requested with FOTA status %d", status);
 
-	err = zbus_chan_pub(&FOTA_CHAN, &evt, K_SECONDS(1));
+	err = zbus_chan_pub(&FOTA_CHAN, &evt, PUB_TIMEOUT);
 	if (err) {
 		LOG_DBG("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -283,7 +283,7 @@ static void fota_status(enum nrf_cloud_fota_status status, const char *const sta
 		return;
 	}
 
-	err = zbus_chan_pub(&FOTA_CHAN, &evt, K_SECONDS(1));
+	err = zbus_chan_pub(&FOTA_CHAN, &evt, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -418,7 +418,7 @@ static void state_polling_for_update_entry(void *obj)
 
 		enum fota_msg_type evt = FOTA_NO_AVAILABLE_UPDATE;
 
-		err = zbus_chan_pub(&FOTA_CHAN, &evt, K_SECONDS(1));
+		err = zbus_chan_pub(&FOTA_CHAN, &evt, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("zbus_chan_pub, error: %d", err);
 			SEND_FATAL_ERROR();

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -99,7 +99,7 @@ static void on_modem_init(int ret, void *ctx)
 		return;
 	}
 
-	err = zbus_chan_pub(&PRIV_LOCATION_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_LOCATION_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -195,7 +195,7 @@ static void cloud_request_send(const struct location_data_cloud *cloud_request)
 		return;
 	}
 
-	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -213,7 +213,7 @@ static void agnss_request_send(const struct nrf_modem_gnss_agnss_data_frame *agn
 		.agnss_request = *agnss_request
 	};
 
-	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -238,7 +238,7 @@ static void gnss_location_send(const struct location_data *location_data)
 		return;
 	}
 
-	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -253,7 +253,7 @@ static void message_send(enum location_msg_type msg_type)
 		.type = msg_type
 	};
 
-	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, K_SECONDS(1));
+	err = zbus_chan_pub(&LOCATION_CHAN, &location_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -133,7 +133,7 @@ static void network_status_notify(enum network_msg_type status)
 		.type = status,
 	};
 
-	err = zbus_chan_pub(&NETWORK_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&NETWORK_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -145,7 +145,7 @@ static void network_msg_send(const struct network_msg *msg)
 {
 	int err;
 
-	err = zbus_chan_pub(&NETWORK_CHAN, msg, K_SECONDS(1));
+	err = zbus_chan_pub(&NETWORK_CHAN, msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/network/network_shell.c
+++ b/app/src/modules/network/network_shell.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/zbus/zbus.h>
 
+#include "app_common.h"
 #include "network.h"
 
 LOG_MODULE_DECLARE(network, CONFIG_APP_NETWORK_LOG_LEVEL);
@@ -23,7 +24,7 @@ static int cmd_connect(const struct shell *sh, size_t argc, char **argv)
 		.type = NETWORK_CONNECT,
 	};
 
-	err = zbus_chan_pub(&NETWORK_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&NETWORK_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;
@@ -42,7 +43,7 @@ static int cmd_disconnect(const struct shell *sh, size_t argc, char **argv)
 		.type = NETWORK_DISCONNECT,
 	};
 
-	err = zbus_chan_pub(&NETWORK_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&NETWORK_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		(void)shell_print(sh, "zbus_chan_pub, error: %d", err);
 		return 1;

--- a/app/src/modules/power/power.c
+++ b/app/src/modules/power/power.c
@@ -119,7 +119,7 @@ static void on_modem_init(int ret, void *ctx)
 		return;
 	}
 
-	err = zbus_chan_pub(&PRIV_POWER_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&PRIV_POWER_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -552,7 +552,7 @@ static void sample(int64_t *ref_time)
 		return;
 	}
 
-	err = zbus_chan_pub(&POWER_CHAN, &msg, K_NO_WAIT);
+	err = zbus_chan_pub(&POWER_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/power/power_shell.c
+++ b/app/src/modules/power/power_shell.c
@@ -10,6 +10,7 @@
 #include <zephyr/logging/log.h>
 #include <errno.h>
 
+#include "app_common.h"
 #include "power.h"
 
 LOG_MODULE_DECLARE(power, CONFIG_APP_POWER_LOG_LEVEL);
@@ -46,7 +47,7 @@ static int cmd_power_sample(const struct shell *shell, size_t argc, char **argv)
 		.type = POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST,
 	};
 
-	err = zbus_chan_pub(&POWER_CHAN, &msg, K_NO_WAIT);
+	err = zbus_chan_pub(&POWER_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		shell_print(shell, "Failed to send request: %d", err);
 		return err;

--- a/app/src/modules/storage/storage.c
+++ b/app/src/modules/storage/storage.c
@@ -31,9 +31,6 @@
 /* Register log module */
 LOG_MODULE_REGISTER(storage, CONFIG_APP_STORAGE_LOG_LEVEL);
 
-/* Timeout for pipe operations */
-#define STORAGE_PIPE_TIMEOUT_MS			50
-
 /* Timeout for batch session activity (to prevent stuck sessions) */
 #define STORAGE_SESSION_TIMEOUT_SECONDS		CONFIG_APP_STORAGE_SESSION_TIMEOUT_SECONDS
 
@@ -231,7 +228,7 @@ static void session_timeout_work_fn(struct k_work *work)
 
 	LOG_WRN("Session timeout: closing session 0x%X", state->current_session.session_id);
 
-	err = zbus_chan_pub(&PRIV_STORAGE_CHAN, &msg, K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+	err = zbus_chan_pub(&PRIV_STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to publish session timeout message: %d", err);
 		/* If we fail to publish, we can't do much else from work queue context */
@@ -326,8 +323,7 @@ static void check_and_notify_buffer_threshold(const struct storage_state *state_
 			.data_len = (uint16_t)count,
 		};
 
-		err = zbus_chan_pub(&STORAGE_CHAN, &threshold_msg,
-				    K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+		err = zbus_chan_pub(&STORAGE_CHAN, &threshold_msg, PUB_TIMEOUT);
 		if (err) {
 			LOG_ERR("Failed to publish buffer threshold message, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -394,8 +390,7 @@ static void flush_stored_data(void)
 
 			msg.data_len = (uint16_t)ret;
 
-			ret = zbus_chan_pub(&STORAGE_DATA_CHAN, &msg,
-					    K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+			ret = zbus_chan_pub(&STORAGE_DATA_CHAN, &msg, PUB_TIMEOUT);
 			if (ret) {
 				LOG_ERR("Failed to publish %s data, error: %d", type->name, ret);
 				SEND_FATAL_ERROR();
@@ -459,7 +454,7 @@ static void send_batch_response(enum storage_msg_type response_type,
 	response_msg.data_len = (uint16_t)MIN(data_len, (size_t)UINT16_MAX);
 	response_msg.more_data = more_data;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &response_msg, K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+	err = zbus_chan_pub(&STORAGE_CHAN, &response_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to send batch response type %d: %d", response_type, err);
 		SEND_FATAL_ERROR();
@@ -568,8 +563,7 @@ static int populate_pipe(struct storage_state *state_object)
 			__ASSERT_NO_MSG(ret == (int)header->data_size);
 
 			/* Write combined buffer atomically to pipe */
-			ret = pipe_write_all(&storage_pipe, item_buffer, total_size,
-					     K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+			ret = pipe_write_all(&storage_pipe, item_buffer, total_size, PUB_TIMEOUT);
 			if (ret < 0) {
 				/* This should never happen since we checked space above */
 				LOG_ERR("Unexpected pipe write failure after space check: %d", ret);
@@ -937,7 +931,7 @@ static enum smf_state_result state_buffer_pipe_active_run(void *o)
 				close_msg.session_id);
 
 			/* Notify other modules (like cloud) that the batch is closed */
-			zbus_chan_pub(&STORAGE_CHAN, &close_msg, K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+			zbus_chan_pub(&STORAGE_CHAN, &close_msg, PUB_TIMEOUT);
 
 			/* Force transition to idle state */
 			smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
@@ -988,8 +982,7 @@ static void storage_thread(void)
 		return;
 	}
 
-	err = zbus_chan_add_obs(&STORAGE_CHAN, &storage_subscriber,
-				K_MSEC(STORAGE_PIPE_TIMEOUT_MS));
+	err = zbus_chan_add_obs(&STORAGE_CHAN, &storage_subscriber, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to add observer to STORAGE_CHAN, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/storage/storage_shell.c
+++ b/app/src/modules/storage/storage_shell.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/zbus/zbus.h>
 
+#include "app_common.h"
 #include "storage.h"
 #include "storage_data_types.h" /* For STORAGE_CHAN */
 
@@ -22,7 +23,7 @@ static int cmd_storage_flush(const struct shell *sh, size_t argc, char **argv)
 	struct storage_msg msg = { .type = STORAGE_FLUSH };
 	int err;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		shell_error(sh, "Failed to publish STORAGE_FLUSH: %d", err);
 		return err;
@@ -40,7 +41,7 @@ static int cmd_storage_batch_request(const struct shell *sh, size_t argc, char *
 	struct storage_msg msg = { .type = STORAGE_BATCH_REQUEST, .session_id = 0x12345678 };
 	int err;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		shell_error(sh, "Failed to publish STORAGE_BATCH_REQUEST: %d", err);
 		return err;
@@ -59,7 +60,7 @@ static int cmd_storage_clear(const struct shell *sh, size_t argc, char **argv)
 	struct storage_msg msg = { .type = STORAGE_CLEAR };
 	int err;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		shell_error(sh, "Failed to publish STORAGE_CLEAR: %d", err);
 		return err;
@@ -77,7 +78,7 @@ static int cmd_storage_batch_close(const struct shell *sh, size_t argc, char **a
 	struct storage_msg msg = { .type = STORAGE_BATCH_CLOSE, .session_id = 0x12345678 };
 	int err;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		shell_error(sh, "Failed to publish STORAGE_BATCH_CLOSE: %d", err);
 		return err;
@@ -96,7 +97,7 @@ static int cmd_storage_stats(const struct shell *sh, size_t argc, char **argv)
 	struct storage_msg msg = { .type = STORAGE_STATS };
 	int err;
 
-	err = zbus_chan_pub(&STORAGE_CHAN, &msg, K_SECONDS(1));
+	err = zbus_chan_pub(&STORAGE_CHAN, &msg, PUB_TIMEOUT);
 	if (err) {
 		shell_error(sh, "Failed to publish STORAGE_STATS: %d", err);
 		return err;


### PR DESCRIPTION
Change all zbus_chan_pub calls to use the same timeout value, defined as PUB_TIMEOUT in app_common.h.

Completes ATT-257