### PR TITLE
repo: align build scopes with release artifacts

### DIFF
--- a/.github/workflows/attach_release_assets.yml
+++ b/.github/workflows/attach_release_assets.yml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
     with:
       memfault_fw_type: "att"
-      build_all: true
+      build_type: release
 
   attach-assets:
     runs-on: ubuntu-24.04
@@ -32,11 +32,6 @@ jobs:
           with:
            pattern: firmware-*
            merge-multiple: true
-
-        - name: Delete test assets
-          run: |
-            rm -f asset-tracker-template-*-buffer-flash-* asset-tracker-template-*-buffer-ram-*
-            rm -f pmr-*-buffer-flash* pmr-*-buffer-ram*
 
         - name: Deploy release to github
           uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-and-target-test.yml
+++ b/.github/workflows/build-and-target-test.yml
@@ -3,11 +3,15 @@ name: Build and Test
 on:
   workflow_dispatch:
     inputs:
-      build_all:
-        description: Build all board configurations
-        type: boolean
+      build_type:
+        description: "Build scope: minimal (thingy91x only), release (all boards, no test builds), all (everything)"
+        type: choice
+        options:
+          - minimal
+          - release
+          - all
         required: true
-        default: false
+        default: minimal
       device_thingy91x:
         description: 'Test thingy91x'
         type: boolean
@@ -46,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       devices: ${{ steps.setup.outputs.devices }}
-      build_all: ${{ steps.setup.outputs.build_all == 'true' }}
+      build_type: ${{ steps.setup.outputs.build_type }}
       push_memory_badges: ${{ steps.setup.outputs.push_memory_badges == 'true' }}
     steps:
       - name: Setup
@@ -57,11 +61,11 @@ jobs:
           push_memory_badges=false
           if [[ $SCHEDULED == true ]]; then
             devices="thingy91x nrf9151dk ppk_thingy91x gnss_nrf9151dk prov_thingy91x"
-            build_all=true
+            build_type=all
             push_memory_badges=true
           elif [[ $PUSH == true ]]; then
             devices="thingy91x"
-            build_all=false
+            build_type=minimal
           else
             # Build devices list from selected checkboxes
             devices=""
@@ -82,20 +86,20 @@ jobs:
             fi
             # Trim leading space
             devices=$(echo "$devices" | xargs)
-            build_all=${{ inputs.build_all }}
+            build_type=${{ inputs.build_type }}
           fi
           echo "devices=$devices"
-          echo "build_all=$build_all"
+          echo "build_type=$build_type"
           echo "push_memory_badges=$push_memory_badges"
           echo "devices=$devices" >> $GITHUB_OUTPUT
-          echo "build_all=$build_all" >> $GITHUB_OUTPUT
+          echo "build_type=$build_type" >> $GITHUB_OUTPUT
           echo "push_memory_badges=$push_memory_badges" >> $GITHUB_OUTPUT
   build:
     needs: setup
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      build_all: ${{ needs.setup.outputs.build_all == 'true' }}
+      build_type: ${{ needs.setup.outputs.build_type }}
       push_memory_badges: ${{ needs.setup.outputs.push_memory_badges == 'true' }}
   test:
     permissions:
@@ -109,4 +113,3 @@ jobs:
       artifact_fw_version: ${{ needs.build.outputs.version }}
       artifact_run_id: ${{ needs.build.outputs.run_id }}
       devices: ${{ needs.setup.outputs.devices }}
-      test_all: ${{ needs.setup.outputs.build_all == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,15 @@ on:
         type: string
         required: false
         default: "att-dev"
-      build_all:
-        description: Build for all targets
-        type: boolean
-        required: false
-        default: false
+      build_type:
+        description: "Build scope: minimal (thingy91x only), release (all boards, no test builds), all (everything)"
+        type: choice
+        options:
+          - minimal
+          - release
+          - all
+        required: true
+        default: minimal
       push_memory_badges:
         description: Whether to parse thingy91x build log and push memory badges
         type: boolean
@@ -28,10 +32,10 @@ on:
         type: boolean
         required: false
         default: false
-      build_all:
-        type: boolean
+      build_type:
+        type: string
         required: false
-        default: false
+        default: minimal
       push_memory_badges:
         type: boolean
         required: false
@@ -137,6 +141,9 @@ jobs:
           python3 scripts/app_version.py ${GITHUB_REF_NAME} > app/VERSION
           cat app/VERSION
 
+      - name: Set build type
+        run: echo "build_type=${{ inputs.build_type || 'minimal' }}" >> $GITHUB_ENV
+
       - name: Set MEMFAULT_FW_TYPE and MEMFAULT_FW_VERSION_PREFIX
         shell: bash
         run: |
@@ -148,6 +155,7 @@ jobs:
 
       # Asset Tracker Template firmware build
       - name: Build thingy91x firmware
+        if: ${{ env.build_type == 'minimal' || env.build_type == 'release' || env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: thingy91x/nrf9151/ns
@@ -177,7 +185,7 @@ jobs:
               ../artifacts/ram_report_thingy91x.html
 
       - name: Build nrf9151dk firmware
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'release' || env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: nrf9151dk/nrf9151/ns
@@ -187,7 +195,7 @@ jobs:
 
       # Asset Tracker Template debug firmware build
       - name: Build thingy91x debug firmware
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'release' || env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           memfault_project_key: ${{ secrets.MEMFAULT_PROJECT_KEY }}
@@ -199,9 +207,9 @@ jobs:
           path: asset-tracker-template/app
           debug: true
 
-      # Asset Tracker Template firmware build with MQTT cloud moduel for Thingy91x
+      # Asset Tracker Template firmware build with MQTT cloud module for Thingy91x
       - name: Build thingy91x firmware with MQTT cloud module
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: thingy91x/nrf9151/ns
@@ -211,7 +219,7 @@ jobs:
           mqtt: true
 
       - name: Build thingy91x firmware with buffered mode flash backend
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: thingy91x/nrf9151/ns
@@ -221,7 +229,7 @@ jobs:
           buffer_flash: true
 
       - name: Build thingy91x firmware with buffered mode RAM backend
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: thingy91x/nrf9151/ns
@@ -231,7 +239,7 @@ jobs:
           buffer_ram: true
 
       - name: Build thingy91x with modem trace on uart
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'release' || env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: thingy91x/nrf9151/ns
@@ -241,7 +249,7 @@ jobs:
           path: asset-tracker-template/app
 
       - name: Build nrf9151dk with modem trace on uart
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'release' || env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: nrf9151dk/nrf9151/ns
@@ -251,7 +259,7 @@ jobs:
           path: asset-tracker-template/app
 
       - name: Build nrf9151dk with external GNSS antenna
-        if: ${{ inputs.build_all }}
+        if: ${{ env.build_type == 'release' || env.build_type == 'all' }}
         uses: ./asset-tracker-template/.github/actions/build-step
         with:
           board: nrf9151dk/nrf9151/ns

--- a/docs/common/release.md
+++ b/docs/common/release.md
@@ -21,7 +21,6 @@ The Asset Tracker Template generates multiple firmware artifacts for different h
 | **Artifact name** | **Hardware platform** | **Description** | **Use case** |
 |-------------------|----------------------|----------------|--------------|
 | `asset-tracker-template-{VERSION}-debug-thingy91x-nrf91.hex` | Thingy:91 X (nRF9151) | Debug build with enhanced logging and diagnostic features. **Note: This build uploads diagnostic and crash data to Memfault using Nordic's account and is intended for internal use only.** | Development debugging and issue investigation |
-| `asset-tracker-template-{VERSION}-mqtt-thingy91x-nrf91.hex` | Thingy:91 X (nRF9151) | Firmware with MQTT cloud connectivity instead of CoAP | Testing MQTT-based cloud communication |
 
 #### Specialized configuration variants
 

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -46,9 +46,11 @@ export NRFCLOUD_API_KEY=<your_nrfcloud_api_key>
 
 Run desired tests, example commands
 ```shell
+# Use -m "not slow" to skip long-running tests (FOTA, memfault, etc.)
 pytest -s -v -m "not slow" tests
 pytest -s -v -m "not slow" tests/test_functional/test_network_reconnect.py
 pytest -s -v -m "not slow" tests/test_functional/test_sampling.py
+# Use -m "slow" to run only the long-running tests
 pytest -s -v -m "slow" tests/test_functional/test_fota.py::test_full_mfw_fota
 ```
 


### PR DESCRIPTION
Replace `build_all` with `build_type` so workflows can distinguish
`minimal`, `release`, and `all` builds.

Limit release runs to shipping artifacts, drop cleanup for test assets,
and stop publishing the MQTT release artifact in `release.md`.

Update on-target test docs to clarify `slow` vs `not slow` pytest usage.