### PR TITLE
modules: restore lost API comments

### DIFF
--- a/app/src/modules/environmental/environmental.h
+++ b/app/src/modules/environmental/environmental.h
@@ -52,6 +52,7 @@ struct environmental_msg {
 	 *  This is either:
 	 * - Unix time in milliseconds if the system clock was synchronized at sampling time, or
 	 * - Uptime in milliseconds if the system clock was not synchronized at sampling time.
+	 * Only valid for ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE events.
 	 */
 	int64_t timestamp;
 };

--- a/app/src/modules/location/location.h
+++ b/app/src/modules/location/location.h
@@ -194,6 +194,7 @@ struct location_msg {
 	 *  This is either:
 	 * - Unix time in milliseconds if the system clock was synchronized at sampling time, or
 	 * - Uptime in milliseconds if the system clock was not synchronized at sampling time.
+	 * Only valid for LOCATION_GNSS_DATA events.
 	 */
 	int64_t timestamp;
 };

--- a/app/src/modules/power/power.h
+++ b/app/src/modules/power/power.h
@@ -51,6 +51,7 @@ struct power_msg {
 	 *  This is either:
 	 * - Unix time in milliseconds if the system clock was synchronized at sampling time, or
 	 * - Uptime in milliseconds if the system clock was not synchronized at sampling time.
+	 * Only valid for POWER_BATTERY_PERCENTAGE_SAMPLE_RESPONSE events.
 	 */
 	int64_t timestamp;
 };


### PR DESCRIPTION
Restore comments describing the validity of the timestamp field in the sample response events for the environmental, location and power modules. were lost during rewrite from uptime to timestamp.