### PR TITLE
docs: Generate index.md from readme.md

### DIFF
--- a/.github/workflows/zoomin-publish-dev.yml
+++ b/.github/workflows/zoomin-publish-dev.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
     paths:
-      - docs
+      - 'docs/**'
   workflow_dispatch:
-    push:
-    branches:
-      - main
 
 jobs:
   create-zoomin-bundle:

--- a/.github/workflows/zoomin-publish.yml
+++ b/.github/workflows/zoomin-publish.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
     paths:
-      - docs
+      - 'docs/**'
   workflow_dispatch:
-    push:
-    branches:
-      - main
 
 jobs:
   create-zoomin-bundle:

--- a/README.md
+++ b/README.md
@@ -1,30 +1,13 @@
 # Asset Tracker Template
 
-<table>
-  <tr>
-    <th>Project</th>
-    <td>
-      <a href="https://github.com/nrfconnect/Asset-Tracker-Template/releases"><img src="https://img.shields.io/github/v/release/nrfconnect/Asset-Tracker-Template" alt="Release"></a>
-      <a href="https://sonarcloud.io/dashboard?id=nrfconnect_Asset-Tracker-Template"><img src="https://sonarcloud.io/api/project_badges/measure?project=nrfconnect_Asset-Tracker-Template&metric=alert_status" alt="Quality Gate"></a>
-      <a href="https://sonarcloud.io/dashboard?id=nrfconnect_Asset-Tracker-Template"><img src="https://sonarcloud.io/api/project_badges/measure?project=nrfconnect_Asset-Tracker-Template&metric=coverage" alt="Coverage"></a>
-    </td>
-  </tr>
-  <tr>
-    <th>CI</th>
-    <td>
-      <a href="https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Apush"><img src="https://img.shields.io/github/actions/workflow/status/nrfconnect/Asset-Tracker-Template/build-and-target-test.yml?event=push&branch=main&label=on-commit" alt="On-commit"></a>
-      <a href="https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Aschedule"><img src="https://img.shields.io/github/actions/workflow/status/nrfconnect/Asset-Tracker-Template/build-and-target-test.yml?event=schedule&branch=main&label=nightly" alt="Nightly"></a>
-    </td>
-  </tr>
-  <tr>
-    <th>Metrics</th>
-    <td>
-      <a href="https://nrfconnect.github.io/Asset-Tracker-Template/power_measurements_plot.html"><img src="https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/power_badge.json" alt="PSM Current"></a>
-      <a href="https://nrfconnect.github.io/Asset-Tracker-Template/ram_memory_view.html"><img src="https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/ram_badge.json" alt="RAM Usage thingy91x"></a>
-      <a href="https://nrfconnect.github.io/Asset-Tracker-Template/flash_memory_view.html"><img src="https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/flash_badge.json" alt="FLASH Usage thingy91x"></a>
-    </td>
-  </tr>
-</table>
+[![Release](https://img.shields.io/github/v/release/nrfconnect/Asset-Tracker-Template)](https://github.com/nrfconnect/Asset-Tracker-Template/releases)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=nrfconnect_Asset-Tracker-Template&metric=alert_status)](https://sonarcloud.io/dashboard?id=nrfconnect_Asset-Tracker-Template)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nrfconnect_Asset-Tracker-Template&metric=coverage)](https://sonarcloud.io/dashboard?id=nrfconnect_Asset-Tracker-Template)
+[![On-commit](https://img.shields.io/github/actions/workflow/status/nrfconnect/Asset-Tracker-Template/build-and-target-test.yml?event=push&branch=main&label=on-commit)](https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Apush)
+[![Nightly](https://img.shields.io/github/actions/workflow/status/nrfconnect/Asset-Tracker-Template/build-and-target-test.yml?event=schedule&branch=main&label=nightly)](https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Aschedule)
+[![PSM Current](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/power_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/power_measurements_plot.html)
+[![RAM Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/ram_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/ram_memory_view.html)
+[![FLASH Usage thingy91x](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/flash_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/flash_memory_view.html)
 
 ## Overview
 
@@ -42,9 +25,16 @@ Modules communicate through [zbus](https://docs.zephyrproject.org/latest/service
 
 If you are new to nRF91 series and cellular IoT, consider taking the [Nordic Developer Academy Cellular Fundamentals Course](https://academy.nordicsemi.com/courses/cellular-iot-fundamentals).
 
+<p align="center">
+  <img src="docs/images/att-map.png" alt="nRF Cloud - Asset tracking map view" width="800" />
+</p>
+
+---
+
 ## Quick Start
 
-The fastest way to get started is to download and run the [Quick Start app](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html) in [nRF Connect for Desktop](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop). It provides a guided setup and provisioning process that gets your device connected to [nRF Cloud](https://nrfcloud.com) in minutes.
+> [!TIP]
+> The fastest way to get started is to download and run the [Quick Start app](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html) in [nRF Connect for Desktop](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop). It provides a guided setup and provisioning process that gets your device connected to [nRF Cloud](https://nrfcloud.com) in minutes.
 
 Alternatively, you can download pre-built firmware binaries from the latest release and flash them directly to your device. See the [release artifacts](docs/common/release.md) documentation for details.
 
@@ -146,13 +136,44 @@ After building and flashing (using either option above), you need to provision t
     <img src="docs/images/claim.png" alt="Claim Device" width="300" />
     </details>
 
-5. After claiming, wait for the device to provision credentials and connect to nRF Cloud over CoAP. Once connected, the device will be available under **Device Management** → **Devices**.
-
-> [!NOTE]
-> The device polls the provisioning service at its own interval. This means it may take a few minutes for the device to pick up the claim and complete provisioning. If you want a quicker response, press **Button 1** on the device or reset it to trigger an immediate provisioning poll.
+5. After claiming, wait for the device to provision credentials and connect to nRF Cloud over CoAP. Once connected, the device will be available under **Device Management** → **Devices**. If you want a quicker response, press and hold **Button 1** on the device or reset it to trigger an immediate provisioning poll.
 
 See [Provisioning to nRF Cloud](docs/common/provisioning.md) for more details.
 </details>
+
+---
+
+## Documentation
+
+<table>
+  <tr>
+    <td><a href="docs/common/getting_started.md">Getting Started</a></td>
+    <td><a href="docs/common/architecture.md">Architecture</a></td>
+    <td><a href="docs/common/configuration.md">Configuration</a></td>
+  </tr>
+  <tr>
+    <td><a href="docs/common/customization.md">Customization</a></td>
+    <td><a href="docs/modules/index.md">Modules</a></td>
+    <td><a href="docs/common/provisioning.md">Provisioning</a></td>
+  </tr>
+  <tr>
+    <td><a href="docs/common/location_services.md">Location Services</a></td>
+    <td><a href="docs/common/low_power.md">Achieving Low Power</a></td>
+    <td><a href="docs/common/fota.md">Firmware Updates (FOTA)</a></td>
+  </tr>
+  <tr>
+    <td><a href="docs/common/test_and_ci_setup.md">Testing and CI Setup</a></td>
+    <td><a href="docs/common/tooling_troubleshooting.md">Tooling and Troubleshooting</a></td>
+    <td><a href="docs/common/known_issues.md">Known Issues</a></td>
+  </tr>
+  <tr>
+    <td><a href="docs/common/release.md">Release Artifacts</a></td>
+    <td><a href="docs/common/release_notes.md">Release Notes</a></td>
+    <td></td>
+  </tr>
+</table>
+
+---
 
 ## System Architecture
 
@@ -177,49 +198,3 @@ Core modules include:
 * **Message-Based Communication**: Loose coupling via [zbus](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/zbus/index.html) channels
 * **Modular Architecture**: Separation of concerns with dedicated threads for blocking operations
 * **Power Optimization**: LTE PSM enabled by default with configurable power-saving features
-
-The architecture is detailed in the [Architecture documentation](docs/common/architecture.md).
-
-## Table of Content
-
-* [Getting Started](docs/common/getting_started.md)
-* [Provisioning to nRF Cloud](docs/common/provisioning.md)
-* [Architecture](docs/common/architecture.md)
-  * [System Overview](docs/common/architecture.md#system-overview)
-  * [Zbus](docs/common/architecture.md#zbus)
-  * [State Machine Framework](docs/common/architecture.md#state-machine-framework)
-* [Configurability](docs/common/configuration.md)
-  * [Set sampling interval and logic from cloud](docs/common/configuration.md#set-sampling-interval-and-logic-from-cloud)
-  * [Set location method priorities](docs/common/configuration.md#set-location-method-priorities)
-  * [Network configuration](docs/common/configuration.md#network-configuration)
-  * [LED Status Indicators](docs/common/configuration.md#led-status-indicators)
-* [Customization](docs/common/customization.md)
-  * [Add a new zbus event](docs/common/customization.md#add-a-new-zbus-event)
-  * [Add environmental sensor](docs/common/customization.md#add-environmental-sensor)
-  * [Add your own module](docs/common/customization.md#add-your-own-module)
-  * [Enable support for MQTT](docs/common/customization.md#enable-support-for-mqtt)
-* [Location Services](docs/common/location_services.md)
-* [Achieving Low Power](docs/common/low_power.md)
-* [Test and CI Setup](docs/common/test_and_ci_setup.md)
-* [Firmware Updates (FOTA)](docs/common/fota.md)
-* [Tooling and Troubleshooting](docs/common/tooling_troubleshooting.md)
-  * [Shell Commands](docs/common/tooling_troubleshooting.md#shell-commands)
-  * [Debugging Tools](docs/common/tooling_troubleshooting.md#debugging-tools)
-  * [Memfault Remote Debugging](docs/common/tooling_troubleshooting.md#memfault-remote-debugging)
-  * [Modem Tracing](docs/common/tooling_troubleshooting.md#modem-tracing)
-  * [Common Issues and Solutions](docs/common/tooling_troubleshooting.md#common-issues-and-solutions)
-* [Known Issues](docs/common/known_issues.md)
-* [Release artifacts](docs/common/release.md)
-
-### Module Documentation
-
-* [Button](docs/modules/button.md)
-* [Cloud](docs/modules/cloud.md)
-* [Storage](docs/modules/storage.md)
-* [Environmental](docs/modules/environmental.md)
-* [FOTA](docs/modules/fota_module.md)
-* [LED](docs/modules/led.md)
-* [Location](docs/modules/location.md)
-* [Main](docs/modules/main.md)
-* [Network](docs/modules/network.md)
-* [Power](docs/modules/power.md)

--- a/docs/common/configuration.md
+++ b/docs/common/configuration.md
@@ -2,34 +2,6 @@
 
 This section describes the available compile-time and runtime configuration options for customizing the template's behavior.
 
-<div class="hidden-content">
-
-## Table of Contents
-
-- [Runtime configurations](#runtime-configurations)
-  - [Behavior:](#behavior)
-- [Remote configuration from cloud](#remote-configuration-from-cloud)
-  - [Configuration through nRF Cloud UI](#configuration-through-nrf-cloud-ui)
-  - [Configuration through REST API](#configuration-through-rest-api)
-  - [Sending commands through REST API](#sending-commands-through-rest-api)
-  - [Configuration Flow](#configuration-flow)
-- [Set location method priorities](#set-location-method-priorities)
-  - [Available location methods](#available-location-methods)
-  - [Configuration examples](#configuration-examples)
-- [Storage configuration](#storage-configuration)
-  - [Basic configuration in `prj.conf`:](#basic-configuration-in-prjconf)
-- [Network configuration](#network-configuration)
-  - [NB-IoT vs. LTE-M](#nb-iot-vs-lte-m)
-    - [Network mode selection](#network-mode-selection)
-    - [Network mode preference](#network-mode-preference)
-  - [Power Saving Mode (PSM)](#power-saving-mode-psm)
-    - [PSM parameters](#psm-parameters)
-  - [Access Point Name (APN)](#access-point-name-apn)
-- [LED status indicators](#led-status-indicators)
-  - [Example: Setting LED colors](#example-setting-led-colors)
-
-</div>
-
 ## Runtime configurations
 
 The device supports runtime configurations that allow you to modify the template's behavior without firmware updates.

--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -8,37 +8,6 @@ For more knowledge on debugging and troubleshooting [nRF Connect SDK](https://gi
 - [nRF Connect SDK Debugging Guide](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/test_and_optimize/debugging.html)
 - [Zephyr Debugging Guide](https://docs.zephyrproject.org/latest/develop/debug/index.html)
 
-<div class="hidden-content">
-
-## Table of Contents
-
-- [Shell Commands](#shell-commands)
-  - [Available Commands](#available-commands)
-  - [Shell Command Examples](#shell-command-examples)
-    - [Cloud Publishing](#cloud-publishing)
-    - [Network disconnect](#network-disconnect)
-    - [AT Command Execution](#at-command-execution)
-- [Debugging Tools](#debugging-tools)
-  - [Low Power Profiling](#low-power-profiling)
-  - [GDB Debugging](#gdb-debugging)
-  - [SEGGER SystemView](#segger-systemview)
-    - [Configuration](#configuration)
-  - [Thread Analysis](#thread-analysis)
-  - [Hardfaults](#hardfaults)
-  - [State Inspection Script](#state-inspection-script)
-- [Memfault Remote Debugging](#memfault-remote-debugging)
-  - [When to Use Memfault](#when-to-use-memfault)
-  - [Prerequisites](#prerequisites)
-  - [Test shell commands](#test-shell-commands)
-- [Modem Tracing](#modem-tracing)
-  - [UART Tracing](#uart-tracing)
-  - [RTT Tracing](#rtt-tracing)
-  - [Dumping modem traces over UART after capture](#dumping-modem-traces-over-uart-after-capture)
-  - [Application logs and modem traces over RTT - Parallel capture](#application-logs-and-modem-traces-over-rtt---parallel-capture)
-- [Common Issues and Solutions](#common-issues-and-solutions)
-
-</div>
-
 ## Shell Commands
 
 The template provides several shell commands for controlling and monitoring device behavior. Connect to the device's UART interface using either:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,10 @@ The system is organized into modules, each responsible for a specific functional
 
 If you are new to nRF91 series and cellular IoT, consider taking the [Nordic Developer Academy Cellular Fundamentals Course](https://academy.nordicsemi.com/courses/cellular-iot-fundamentals).
 
+<p align="center">
+  <img src="images/att-map.png" alt="nRF Cloud - Asset tracking map view" width="800" />
+</p>
+
 ## Quick Start
 
 The fastest way to get started is to download and run the [Quick Start app](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html) in [nRF Connect for Desktop](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop). It provides a guided setup and provisioning process that gets your device connected to [nRF Cloud](https://nrfcloud.com) in minutes.
@@ -29,15 +33,15 @@ Use the [nRF Connect for VS Code](https://docs.nordicsemi.com/bundle/nrf-connect
 2. Open VS Code and go to the **nRF Connect** extension.
 3. Select **Create New Application**.
 4. Select **Browse nRF Connect SDK add-on Index**.
-4. Search for **Asset Tracker Template** and create the project.
-5. Use the **Actions** panel in the extension to build and flash the application.
+5. Search for **Asset Tracker Template** and create the project.
+6. Use the **Actions** panel in the extension to build and flash the application.
 
 ### Option 2: Command line
 
 <details>
 <summary><strong>1. Initialize workspace</strong></summary>
 <ol>
-<li>Install nRF Util. Follow <a href="https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html">documentation</a> for installation instructions.</li>
+<li>Install nRF Util. Follow the <a href="https://docs.nordicsemi.com/bundle/nrfutil/page/guides/installing.html">nRF Util documentation</a> for installation instructions.</li>
 <li>Install sdk-manager:
 <pre><code class="language-bash">nrfutil install sdk-manager</code></pre>
 </li>
@@ -48,7 +52,7 @@ Use the [nRF Connect for VS Code](https://docs.nordicsemi.com/bundle/nrf-connect
 <pre><code class="language-bash">nrfutil sdk-manager toolchain launch --ncs-version v3.1.0 --terminal</code></pre>
 This launches a new terminal window with the specified toolchain activated. Use this terminal in the coming steps.
 </li>
-<li>Initialize workspace
+<li>Initialize workspace:
 <pre><code class="language-bash">west init -m https://github.com/nrfconnect/Asset-Tracker-Template.git --mr main asset-tracker-template
 cd asset-tracker-template/project/app
 west update</code></pre>
@@ -88,12 +92,9 @@ After building and flashing (using either option above), you need to provision t
 <li>Get the device attestation token. Open a serial terminal connected to the device (115200 baud) and run the following AT command in the device shell:
 <pre><code class="language-bash">at at%attesttoken</code></pre>
 The token is also printed automatically to the serial log on first boot of unprovisioned devices.</li>
-<li>Log in to the <a href="https://nrfcloud.com/#/">nRF Cloud</a> portal.</li>
-<li>Select <strong>Security Services</strong> in the left sidebar.</li>
-<li>Select <strong>Claimed Devices</strong>.</li>
-<li>Click <strong>Claim Device</strong>.</li>
-<li>Copy and paste the attestation token into the <strong>Claim token</strong> text box.</li>
-<li>Set rule to nRF Cloud Onboarding and click <strong>Claim Device</strong>.</li>
+<li>Log in to the <a href="https://nrfcloud.com">nRF Cloud</a> portal.</li>
+<li>Navigate to <strong>Security Services</strong> → <strong>Claimed Devices</strong> → <strong>Claim Device</strong>.</li>
+<li>Paste the attestation token, set rule to "nRF Cloud Onboarding", and click <strong>Claim Device</strong>.</li>
 
 <details>
 <summary><strong>If "nRF Cloud Onboarding" rule is not showing:</strong></summary>
@@ -103,14 +104,10 @@ Create a new rule using the following configuration:<br>
 <img src="images/claim.png" alt="Claim Device" width="300" />
 </details>
 
-<li>After claiming, wait for the device to provision credentials and connect to nRF Cloud over CoAP. Once connected, the device will be available under the <strong>Devices</strong> section in the <strong>Device Management</strong> navigation pane on the left.</li>
+<li>After claiming, wait for the device to provision credentials and connect to nRF Cloud over CoAP. Once connected, the device will be available under <strong>Device Management</strong> → <strong>Devices</strong>. If you want a quicker response, press and hold <strong>Button 1</strong> on the device or reset it to trigger an immediate provisioning poll.</li>
 </ol>
 
-<blockquote>
-<strong>Note:</strong> The device polls the provisioning service at its own interval. This means it may take a few minutes for the device to pick up the claim and complete provisioning. If you want a quicker response, press and hold <strong>Button 1</strong> on the device or reset the device to trigger an immediate provisioning poll.
-</blockquote>
-
-See <a href="https://docs.nordicsemi.com/bundle/asset-tracker-template-latest/page/common/provisioning.html">provisioning</a> for more details.
+See <a href="common/provisioning.md">Provisioning to nRF Cloud</a> for more details.
 
 </details>
 
@@ -120,5 +117,7 @@ See <a href="https://docs.nordicsemi.com/bundle/asset-tracker-template-latest/pa
 * **Message-Based Communication**: Loose coupling via [zbus](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/zbus/index.html) channels
 * **Modular Architecture**: Separation of concerns with dedicated threads for blocking operations
 * **Power Optimization**: LTE PSM enabled by default with configurable power-saving features
+
+![System overview](images/system_overview.svg)
 
 The architecture is detailed in the [Architecture documentation](common/architecture.md).

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -1,0 +1,14 @@
+# Modules
+
+| Module | Description |
+|--------|-------------|
+| [Main](main.md) | Central coordinator implementing business logic |
+| [Button](button.md) | User input handling |
+| [Cloud](cloud.md) | nRF Cloud CoAP communication |
+| [Environmental](environmental.md) | Sensor data collection |
+| [FOTA](fota_module.md) | Firmware over-the-air updates |
+| [LED](led.md) | RGB LED control for Thingy:91 X |
+| [Location](location.md) | GNSS, Wi-Fi, and cellular positioning |
+| [Network](network.md) | LTE connectivity management |
+| [Power](power.md) | Battery monitoring and power management |
+| [Storage](storage.md) | Data collection and buffering management |

--- a/docs/stylesheets/style.css
+++ b/docs/stylesheets/style.css
@@ -1,4 +1,0 @@
-/* Hide in MkDocs */
-.hidden-content {
-  display: none;
-}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,9 +26,6 @@ theme:
     - toc.follow
 
 
-extra_css:
-  - stylesheets/style.css
-
 copyright:
   Copyright &copy; 2025
 
@@ -63,16 +60,16 @@ nav:
   - Testing and CI setup: common/test_and_ci_setup.md
   - Tooling and Troubleshooting: common/tooling_troubleshooting.md
   - Known Issues: common/known_issues.md
-  - Application modules:
-    - Main module: modules/main.md
-    - Button module: modules/button.md
-    - Cloud module: modules/cloud.md
-    - Environmental module: modules/environmental.md
-    - FOTA module: modules/fota_module.md
-    - LED module: modules/led.md
-    - Location module: modules/location.md
-    - Network module: modules/network.md
-    - Power module: modules/power.md
-    - Storage module: modules/storage.md
+  - Modules:
+    - Main: modules/main.md
+    - Button: modules/button.md
+    - Cloud: modules/cloud.md
+    - Environmental: modules/environmental.md
+    - FOTA: modules/fota_module.md
+    - LED: modules/led.md
+    - Location: modules/location.md
+    - Network: modules/network.md
+    - Power: modules/power.md
+    - Storage: modules/storage.md
   - Release artifacts: common/release.md
   - Release notes: common/release_notes.md


### PR DESCRIPTION
Add hook that generates index.md from readme.md to keep a single source of truth instead of maintaining two files.