### PR TITLE
modules: cloud_location: Accept single cell info

### DIFF
--- a/app/src/modules/cloud/cloud_location.c
+++ b/app/src/modules/cloud/cloud_location.c
@@ -157,8 +157,9 @@ static void handle_cloud_location_request(const struct location_cloud_request_da
 	struct lte_lc_ncell neighbor_cells[CONFIG_LTE_NEIGHBOR_CELLS_MAX];
 	struct lte_lc_cell gci_cells[CONFIG_LTE_NEIGHBOR_CELLS_MAX];
 
-	if ((request->current_cell.id != LTE_LC_CELL_EUTRAN_ID_INVALID) &&
-	    ((request->ncells_count > 0) || (request->gci_cells_count > 0))) {
+	if ((request->current_cell.id != LTE_LC_CELL_EUTRAN_ID_INVALID) ||
+	    (request->ncells_count > 0) ||
+	    (request->gci_cells_count > 0)) {
 		err = cellular_cell_data_construct(&cell_info, neighbor_cells,
 						   ARRAY_SIZE(neighbor_cells),
 						   gci_cells,


### PR DESCRIPTION
Don't ignore single cell info if the location results recieved from the location module only contains single cell.

Prior to this change only valid ncell or gcell was accepted.