### PR TITLE
.github: workflows: sonarcloud: add branch name to analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -108,6 +108,7 @@ jobs:
             --define sonar.coverageReportPaths=coverage.xml
             --define sonar.inclusions=app/src/**/*.c,app/src/**/*.h
             --define sonar.exclusions=tests/**/*
+            --define sonar.branch.name=${{ github.ref_name }}
           projectBaseDir: asset-tracker-template
 
       - name: SonarQube Scan on PR


### PR DESCRIPTION
Pass `sonar.branch.name` using `github.ref_name` so SonarCloud correctly associates analysis results with the triggering branch.