### PR TITLE
.github: workflows: sonarcloud: bump sonarqube-scan-action to v7.1.0

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -68,7 +68,7 @@ jobs:
           west twister -T tests/ --enable-coverage --coverage-platform=native_sim -v --inline-logs --integration --enable-asan --enable-lsan --enable-ubsan
 
       - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6.0.0
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7.1.0
 
       - name: Build and test
         working-directory: asset-tracker-template
@@ -95,7 +95,7 @@ jobs:
 
       - name: SonarQube Scan on main
         if: github.event_name != 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v6.0.0
+        uses: SonarSource/sonarqube-scan-action@v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: SonarQube Scan on PR
         if: github.event_name == 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v6.0.0
+        uses: SonarSource/sonarqube-scan-action@v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Update `SonarSource/sonarqube-scan-action` and
`sonarqube-scan-action/install-build-wrapper` from `v6.0.0` to `v7.1.0`.