### PR TITLE
.github: workflows: sonarcloud: remove sonar.branch.name parameter

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -108,7 +108,6 @@ jobs:
             --define sonar.coverageReportPaths=coverage.xml
             --define sonar.inclusions=app/src/**/*.c,app/src/**/*.h
             --define sonar.exclusions=tests/**/*
-            --define sonar.branch.name=${{ github.ref_name }}
           projectBaseDir: asset-tracker-template
 
       - name: SonarQube Scan on PR


### PR DESCRIPTION
Remove the `sonar.branch.name` definition from the SonarCloud scan step. This parameter is not needed when using the SonarQube GitHub Action, which automatically resolves the branch from context.