### PR TITLE
.github: workflows: build: remove gh-pages merge step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,14 +159,6 @@ jobs:
           # Install required packages
           pip install pandas plotly --break-system-packages
 
-          # Merge main into gh-pages so docs/README stay in sync
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          git merge origin/main -m "Merge main into gh-pages" --no-edit && git push origin gh-pages || echo "Merge failed, skipping"
-          git checkout -
-
           # Generate sunburst charts first
           python3 scripts/sunburst_from_mem_report.py ../artifacts/rom_report_thingy91x.json
           python3 scripts/sunburst_from_mem_report.py ../artifacts/ram_report_thingy91x.json


### PR DESCRIPTION
Remove the automatic merge of `main` into `gh-pages` from the build workflow. This step was merging branches to keep docs/README in sync, but is no longer needed as the `gh-pages` branch has been cleaned up and only contains diagrams, not documentation.