### PR TITLE
ci: update SonarCloud project key format

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           args: |
             --define sonar.cfamily.compile-commands=asset-tracker-template/${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
-            --define sonar.projectKey=nrfconnect_Asset-Tracker-Template
+            --define sonar.projectKey=nrfconnect-asset-tracker-template
             --define sonar.organization=nrfconnect
             --define sonar.host.url=https://sonarcloud.io
             --define sonar.coverageReportPaths=coverage.xml
@@ -123,7 +123,7 @@ jobs:
         with:
           args: |
             --define sonar.cfamily.compile-commands=asset-tracker-template/${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
-            --define sonar.projectKey=nrfconnect_Asset-Tracker-Template
+            --define sonar.projectKey=nrfconnect-asset-tracker-template
             --define sonar.organization=nrfconnect
             --define sonar.host.url=https://sonarcloud.io
             --define sonar.coverageReportPaths=coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Asset Tracker Template
 
 [![Release](https://img.shields.io/github/v/release/nrfconnect/Asset-Tracker-Template)](https://github.com/nrfconnect/Asset-Tracker-Template/releases)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=nrfconnect_Asset-Tracker-Template&metric=alert_status)](https://sonarcloud.io/dashboard?id=nrfconnect_Asset-Tracker-Template)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nrfconnect_Asset-Tracker-Template&metric=coverage)](https://sonarcloud.io/dashboard?id=nrfconnect_Asset-Tracker-Template)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=nrfconnect-asset-tracker-template&metric=alert_status)](https://sonarcloud.io/dashboard?id=nrfconnect-asset-tracker-template)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nrfconnect-asset-tracker-template&metric=coverage)](https://sonarcloud.io/dashboard?id=nrfconnect-asset-tracker-template)
 [![On-commit](https://img.shields.io/github/actions/workflow/status/nrfconnect/Asset-Tracker-Template/build-and-target-test.yml?event=push&branch=main&label=on-commit)](https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Apush)
 [![Nightly](https://img.shields.io/github/actions/workflow/status/nrfconnect/Asset-Tracker-Template/build-and-target-test.yml?event=schedule&branch=main&label=nightly)](https://github.com/nrfconnect/Asset-Tracker-Template/actions/workflows/build-and-target-test.yml?query=branch%3Amain+event%3Aschedule)
 [![PSM Current](https://img.shields.io/endpoint?url=https://nrfconnect.github.io/Asset-Tracker-Template/power_badge.json)](https://nrfconnect.github.io/Asset-Tracker-Template/power_measurements_plot.html)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.projectKey=nrfconnect_Asset-Tracker-Template
+sonar.projectKey=nrfconnect-asset-tracker-template
 sonar.organization=nrfconnect
 sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
Replace underscored `sonar.projectKey` value
`nrfconnect_Asset-Tracker-Template` with the hyphenated format `nrfconnect-asset-tracker-template` in `sonar-project.properties`, the SonarCloud workflow, and the README badge URLs.

This is needed in order to reset the project's server-side state on SonarCloud, which has been rejecting every analysis reports for some time.

Renaming the project
key (and updating the references here to match) is the workaround documented by SonarSource for this stuck-state.