### PR TITLE
app: src: main: combine sensor sampling into `trigger_sampling`

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -487,7 +487,7 @@ static void poll_triggers_send(void)
 
 /* Common helpers for substates */
 
-static void sampling_begin_common(struct main_state *state_object)
+static void trigger_sampling(struct main_state *state_object)
 {
 	int err;
 	struct location_msg location_msg = {
@@ -516,6 +516,34 @@ static void sampling_begin_common(struct main_state *state_object)
 #endif /* CONFIG_APP_LED */
 
 	state_object->sample_start_time = k_uptime_seconds();
+
+#if defined(CONFIG_APP_POWER)
+	struct power_msg power_msg = {
+		.type = POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST,
+	};
+
+	err = zbus_chan_pub(&power_chan, &power_msg, PUB_TIMEOUT);
+	if (err) {
+		LOG_ERR("Failed to publish power battery sample request, error: %d", err);
+		SEND_FATAL_ERROR();
+
+		return;
+	}
+#endif /* CONFIG_APP_POWER */
+
+#if defined(CONFIG_APP_ENVIRONMENTAL)
+	struct environmental_msg environmental_msg = {
+		.type = ENVIRONMENTAL_SENSOR_SAMPLE_REQUEST,
+	};
+
+	err = zbus_chan_pub(&environmental_chan, &environmental_msg, PUB_TIMEOUT);
+	if (err) {
+		LOG_ERR("Failed to publish environmental sensor sample request, error: %d", err);
+		SEND_FATAL_ERROR();
+
+		return;
+	}
+#endif /* CONFIG_APP_ENVIRONMENTAL */
 
 	err = zbus_chan_pub(&location_chan, &location_msg, PUB_TIMEOUT);
 	if (err) {
@@ -570,41 +598,6 @@ static void waiting_entry_common(const struct main_state *state_object)
 static void waiting_exit_common(void)
 {
 	timer_sample_stop();
-}
-
-static void sensor_triggers_send(void)
-{
-	int err;
-
-	(void)err;
-
-#if defined(CONFIG_APP_POWER)
-	struct power_msg power_msg = {
-		.type = POWER_BATTERY_PERCENTAGE_SAMPLE_REQUEST,
-	};
-
-	err = zbus_chan_pub(&power_chan, &power_msg, PUB_TIMEOUT);
-	if (err) {
-		LOG_ERR("Failed to publish power battery sample request, error: %d", err);
-		SEND_FATAL_ERROR();
-
-		return;
-	}
-#endif /* CONFIG_APP_POWER */
-
-#if defined(CONFIG_APP_ENVIRONMENTAL)
-	struct environmental_msg environmental_msg = {
-		.type = ENVIRONMENTAL_SENSOR_SAMPLE_REQUEST,
-	};
-
-	err = zbus_chan_pub(&environmental_chan, &environmental_msg, PUB_TIMEOUT);
-	if (err) {
-		LOG_ERR("Failed to publish environmental sensor sample request, error: %d", err);
-		SEND_FATAL_ERROR();
-
-		return;
-	}
-#endif /* CONFIG_APP_ENVIRONMENTAL */
 }
 
 static void storage_send_data(struct main_state *state_object)
@@ -1254,7 +1247,7 @@ static void disconnected_sampling_entry(void *o)
 	struct main_state *state_object = (struct main_state *)o;
 
 	LOG_DBG("%s", __func__);
-	sampling_begin_common(state_object);
+	trigger_sampling(state_object);
 }
 
 static enum smf_state_result disconnected_sampling_run(void *o)
@@ -1265,7 +1258,6 @@ static enum smf_state_result disconnected_sampling_run(void *o)
 		const struct location_msg *msg = (const struct location_msg *)state_object->msg_buf;
 
 		if (msg->type == LOCATION_SEARCH_DONE) {
-			sensor_triggers_send();
 			smf_set_state(SMF_CTX(state_object), &states[STATE_DISCONNECTED_WAITING]);
 
 			return SMF_EVENT_HANDLED;
@@ -1368,7 +1360,7 @@ static void connected_sampling_entry(void *o)
 	struct main_state *state_object = (struct main_state *)o;
 
 	LOG_DBG("%s", __func__);
-	sampling_begin_common(state_object);
+	trigger_sampling(state_object);
 }
 
 static enum smf_state_result connected_sampling_run(void *o)
@@ -1379,7 +1371,6 @@ static enum smf_state_result connected_sampling_run(void *o)
 		const struct location_msg *msg = (const struct location_msg *)state_object->msg_buf;
 
 		if (msg->type == LOCATION_SEARCH_DONE) {
-			sensor_triggers_send();
 			smf_set_state(SMF_CTX(state_object), &states[STATE_CONNECTED_WAITING]);
 			return SMF_EVENT_HANDLED;
 		}
@@ -1390,6 +1381,14 @@ static enum smf_state_result connected_sampling_run(void *o)
 		const struct button_msg *msg = (const struct button_msg *)state_object->msg_buf;
 
 		if (msg->type == BUTTON_PRESS_SHORT) {
+			return SMF_EVENT_HANDLED;
+		}
+	}
+
+	if (state_object->chan == &storage_chan) {
+		const struct storage_msg *msg = (const struct storage_msg *)state_object->msg_buf;
+
+		if (msg->type == STORAGE_THRESHOLD_REACHED) {
 			return SMF_EVENT_HANDLED;
 		}
 	}

--- a/docs/images/main_module_state_diagram.svg
+++ b/docs/images/main_module_state_diagram.svg
@@ -252,12 +252,12 @@
 			<text x="4" y="1130.16" class="st5">STATE_DISCONNECTED</text>		</g>
 		<g id="shape1044-176" transform="translate(78.2441,-831.737)">
 			<title>Sheet.1044</title>
-			<desc>entry / sampling_begin_common(); LOCATION_SEARCH_DONE ...</desc>
+			<desc>entry / trigger_sampling(); LOCATION_SEARCH_DONE ...</desc>
 			<path d="M0 1129.31 A6.99693 7.3555 -180 0 0 7 1136.66 L226.23 1136.66 A6.99693 7.3555 -180 0 0 233.23 1129.31 L233.23
 						 1076.59 A6.99693 7.3555 -180 0 0 226.23 1069.24 L7 1069.24 A6.99693 7.3555 -180 0 0 -0 1076.59 L0 1129.31
 						 Z" class="st1"/>
 			<text x="4" y="1100.55" class="st6">
-				<tspan x="4" dy="0" class="st10">entry / sampling_begin_common();</tspan>
+				<tspan x="4" dy="0" class="st10">entry / trigger_sampling();</tspan>
 				<tspan x="4" dy="2.4em" class="st10">LOCATION_SEARCH_DONE / ;</tspan>
 				<tspan x="4" dy="1.2em" class="st10">BUTTON_PRESS_SHORT / ignored();</tspan>
 			</text>		</g>
@@ -356,12 +356,12 @@
 			<text x="4" y="1130.16" class="st5">STATE_CONNECTED</text>		</g>
 		<g id="shape1073-238" transform="translate(82.5986,-582.5)">
 			<title>Sheet.1073</title>
-			<desc>entry / sampling_begin_common(); LOCATION_SEARCH_DONE ...</desc>
+			<desc>entry / trigger_sampling(); LOCATION_SEARCH_DONE ...</desc>
 			<path d="M0 1139.31 A6.99693 7.3555 -180 0 0 7 1146.66 L226.23 1146.66 A6.99693 7.3555 -180 0 0 233.23 1139.31 L233.23
 						 1076.59 A6.99693 7.3555 -180 0 0 226.23 1069.24 L7 1069.24 A6.99693 7.3555 -180 0 0 -0 1076.59 L0 1139.31
 						 Z" class="st1"/>
 			<text x="4" y="1100.55" class="st6">
-				<tspan x="4" dy="0" class="st10">entry / sampling_begin_common();</tspan>
+				<tspan x="4" dy="0" class="st10">entry / trigger_sampling();</tspan>
 				<tspan x="4" dy="2.4em" class="st10">LOCATION_SEARCH_DONE / ;</tspan>
 				<tspan x="4" dy="1.2em" class="st10">BUTTON_PRESS_SHORT / ignored();</tspan>
 				<tspan x="4" dy="1.2em" class="st10">STORAGE_THRESHOLD_REACHED / ignored();</tspan>


### PR DESCRIPTION
Rename `sampling_begin_common` to `trigger_sampling` and move the power and environmental sensor sample requests into it, replacing the separate `sensor_triggers_send` function. Sensors are now triggered at sampling entry rather than after `LOCATION_SEARCH_DONE`.

Also handle `STORAGE_THRESHOLD_REACHED` in `connected_sampling_run` to prevent unhandled event propagation.

Update the state diagram SVG to reflect the renamed function.