### PR TITLE
docs: Address feedback from UX testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Use the [nRF Connect for VS Code](https://docs.nordicsemi.com/bundle/nrf-connect
 2. Open VS Code and go to the **nRF Connect** extension.
 3. Select **Create New Application**.
 4. Select **Browse nRF Connect SDK add-on Index**.
-4. Search for **Asset Tracker Template** and create the project.
-5. Use the **Actions** panel in the extension to build and flash the application.
+5. Search for **Asset Tracker Template** and create the project.
+6. In the **Applications** side panel, click **Add build configuration** under **app**.
+7. In the **Add Build Configuration (app)** dialog, set **Board target** to one of the supported build targets — `thingy91x/nrf9151/ns` (Thingy:91 X) or `nrf9151dk/nrf9151/ns` (nRF9151 DK). With the **Compatible** filter selected, only the supported targets are listed.
+8. Click **Generate and Build**, then use the **Actions** panel to flash and debug the application.
 
 ### Option 2: Command line
 
@@ -111,12 +113,16 @@ west flash --erase
 
 For more details, see the [Getting Started Guide](docs/common/getting_started.md).
 
-### Provision device to nRF Cloud
+### Connect device to nRF Cloud
 
-After building and flashing (using either option above), you need to provision the device to connect to [nRF Cloud](https://nrfcloud.com).
+After building and flashing (using either option above), connect the device to [nRF Cloud](https://nrfcloud.com). This involves three steps:
+
+- **Claiming** — registering the device with your nRF Cloud account using the attestation token.
+- **Provisioning** — the device securely receives cloud credentials from the nRF Provisioning Service.
+- **Cloud connection** — the device establishes a CoAP connection to nRF Cloud using the provisioned credentials.
 
 <details>
-<summary><strong>Provisioning steps</strong></summary>
+<summary><strong>Connecting</strong></summary>
 
 1. Get the device attestation token. Open a serial terminal connected to the device (115200 baud) and run the following AT command in the device shell:
 
@@ -124,11 +130,13 @@ After building and flashing (using either option above), you need to provision t
    at at%attesttoken
    ```
 
-   *Note: The token is also printed automatically to the serial log on first boot of unprovisioned devices.*
+   *Note: The token is also printed automatically to the serial log on first boot of unprovisioned devices, labelled `Attestation token:`.*
 
 2. Log in to the [nRF Cloud](https://nrfcloud.com) portal.
 3. Navigate to **Security Services** → **Claimed Devices** → **Claim Device**.
-4. Paste the attestation token, set rule to "nRF Cloud Onboarding", and click **Claim Device**.
+4. Paste the attestation token, set **Provisioning rule** to **nRF Cloud Onboarding**, and click **Claim Device**.
+
+    > **Important:** The **nRF Cloud Onboarding** rule is the named set of provisioning commands that tells nRF Cloud which credentials to deliver to the device. Selecting the correct rule is required.
 
     <details>
     <summary><strong>If "nRF Cloud Onboarding" rule is not showing:</strong></summary>
@@ -138,9 +146,11 @@ After building and flashing (using either option above), you need to provision t
     <img src="docs/images/claim.png" alt="Claim Device" width="300" />
     </details>
 
-5. After claiming, wait for the device to provision credentials and connect to nRF Cloud over CoAP. Once connected, the device will be available under **Device Management** → **Devices**. If you want a quicker response, press and hold **Button 1** on the device or reset it to trigger an immediate provisioning poll.
+5. Press and hold **Button 1** on the device for a couple of seconds to trigger provisioning. On **Thingy:91 X**, pressing on the top of the case pushes Button 1.
 
-See [Provisioning to nRF Cloud](docs/common/provisioning.md) for more details.
+   Once provisioning completes, the device appears under **Device Management** → **Devices**.
+
+See [Connecting to nRF Cloud](docs/common/connecting.md) for more details.
 </details>
 
 ---
@@ -156,7 +166,7 @@ See [Provisioning to nRF Cloud](docs/common/provisioning.md) for more details.
   <tr>
     <td><a href="docs/common/customization.md">Customization</a></td>
     <td><a href="docs/modules/overview_modules.md">Modules</a></td>
-    <td><a href="docs/common/provisioning.md">Provisioning</a></td>
+    <td><a href="docs/common/connecting.md">Connecting</a></td>
   </tr>
   <tr>
     <td><a href="docs/common/location_services.md">Location Services</a></td>

--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  name: Asset Tracker Template
+  description: Modular, event-driven application framework for nRF91-based asset tracking devices.
+tests:
+  asset_tracker_template.app:
+    sysbuild: true
+    build_only: true
+    integration_platforms:
+      - thingy91x/nrf9151/ns
+      - nrf9151dk/nrf9151/ns
+    platform_allow:
+      - thingy91x/nrf9151/ns
+      - nrf9151dk/nrf9151/ns
+    tags:
+      - ci_build
+      - sysbuild

--- a/app/src/modules/cloud/cloud_provisioning.c
+++ b/app/src/modules/cloud/cloud_provisioning.c
@@ -98,9 +98,12 @@ static void nrf_provisioning_callback(const struct nrf_provisioning_callback_dat
 		break;
 	case NRF_PROVISIONING_EVENT_FAILED_DEVICE_NOT_CLAIMED:
 		LOG_WRN("Provisioning failed, device not claimed");
-		LOG_WRN("Claim the device using the device's attestation token on nrfcloud.com");
-		LOG_WRN("\r\n\n%.*s.%.*s\r\n", event->token->attest_sz, event->token->attest,
-					       event->token->cose_sz, event->token->cose);
+		LOG_WRN("Claim the device on nrfcloud.com using the attestation token below");
+		LOG_WRN("Attestation token (copy the entire value between the lines):");
+		LOG_WRN("----- BEGIN ATTESTATION TOKEN -----");
+		LOG_WRN("%.*s.%.*s", event->token->attest_sz, event->token->attest,
+				     event->token->cose_sz, event->token->cose);
+		LOG_WRN("----- END ATTESTATION TOKEN -----");
 
 		msg.type = CLOUD_PROVISIONING_FAILED;
 

--- a/docs/common/configuration.md
+++ b/docs/common/configuration.md
@@ -13,17 +13,17 @@ The template uses separate parameters to control:
 
 Cloud updates include sending data, checking for FOTA jobs, and retrieving configuration/command updates. For implementation details, see [Configuration Flow](#configuration-flow).
 
-| Parameter | Description | Unit | Valid Range | Static Configuration
-|-----------|-------------|------|-------------|---------------------
-| **`update_interval`** | Cloud update interval | Seconds | 1 to 4294967295 | `CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS` (default: 600)
-| **`sample_interval`** | Sample interval | Seconds | 1 to 4294967295 | `CONFIG_APP_SAMPLING_INTERVAL_SECONDS` (default: 150)
-| **`storage_threshold`** | Number of records to store before triggering a cloud update | Records | 0 (disabled) to `CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE` | `CONFIG_APP_STORAGE_THRESHOLD_RECORDS` (default: 1)
+| Parameter | Description | Unit | Valid range | Static configuration |
+|-----------|-------------|------|-------------|----------------------|
+| **`update_interval`** | Cloud update interval | Seconds | 1 to 4294967295 | `CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS` (default: 3600) |
+| **`sample_interval`** | Sample interval | Seconds | 1 to 4294967295 | `CONFIG_APP_SAMPLING_INTERVAL_SECONDS` (default: 600) |
+| **`storage_threshold`** | Number of records to store before triggering a cloud update | Records | 0 (disabled) to `CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE` | `CONFIG_APP_STORAGE_INITIAL_THRESHOLD` (default: 1) |
 
 You can set the runtime configurations through the cloud device shadow and they will override the compile-time Kconfig defaults shown in the Static Configuration column.
 
 The complete device shadow structure is defined in the [CDDL](https://datatracker.ietf.org/doc/html/rfc8610) schema at `Asset-Tracker-Template/app/src/cbor/device_shadow.cddl`. This schema specifies all supported configuration parameters, commands, and their valid value ranges.
 
-### Behavior:
+### Behavior
 
 - Samples sensors and location at `sample_interval`.
 - Buffers data locally.
@@ -73,8 +73,7 @@ The Asset Tracker can be configured remotely through nRF Cloud's device shadow m
     }
     ```
 
-    <blockquote>
-    <strong>IMPORTANT:</strong> To remove a configuration entry you need to explicitly <code>null</code> the parameter.
+    > **Important:** To remove a configuration entry, you must explicitly set the parameter to `null`.
 
 1. Click **Commit** to apply the changes.
 
@@ -122,10 +121,10 @@ curl -X PATCH "https://api.nrfcloud.com/v1/devices/$DEVICE_ID/state" \
 
 For shadow structure details, see `Asset-Tracker-Template/app/src/cbor/device_shadow.cddl`.
 
-### Configuration Flow
+### Configuration flow
 
 Default intervals are set from the `CONFIG_APP_SAMPLING_INTERVAL_SECONDS` and `CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS` Kconfig options,
-and the threshold is set from `CONFIG_APP_STORAGE_THRESHOLD`. When the device polls the shadow, it checks for any updates to these parameters and applies them at runtime. If a parameter is not set in the shadow, the device continues using the existing value (either from Kconfig or a previous shadow update).
+and the threshold is set from `CONFIG_APP_STORAGE_INITIAL_THRESHOLD`. When the device polls the shadow, it checks for any updates to these parameters and applies them at runtime. If a parameter is not set in the shadow, the device continues using the existing value (either from Kconfig or a previous shadow update).
 
 To trigger an immediate configuration poll, press and hold **Button 1** on the device to trigger a cloud update cycle that includes fetching the latest shadow delta.
 
@@ -186,14 +185,14 @@ The following are the available location methods:
 
 The storage module buffers collected data locally and sends it to the cloud based on the configured intervals and thresholds. See [Storage Module Documentation](../modules/storage.md) for details.
 
-### Basic configuration in `prj.conf`:
+### Basic configuration in `prj.conf`
 
 To configure buffer size and records per stored data type:
 
 ```bash
 CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE=8      # Records per data type
 CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE=256       # Batch buffer size
-CONFIG_APP_STORAGE_THRESHOLD=4                 # Number of records to trigger cloud update
+CONFIG_APP_STORAGE_INITIAL_THRESHOLD=4         # Number of records to trigger cloud update
 ```
 
 The `storage_threshold` runtime parameter controls when buffered data is sent to the cloud. Setting it to `0` means data will only be sent based on the `update_interval`, while setting it to `1` means data will be sent immediately after each sample.

--- a/docs/common/connecting.md
+++ b/docs/common/connecting.md
@@ -1,6 +1,12 @@
-# Provisioning
+# Connecting
 
-Device provisioning establishes credentials for secure communication with nRF Cloud CoAP.
+Connecting a device to [nRF Cloud](https://nrfcloud.com) involves three steps:
+
+- **Claiming** — Registering the device with your nRF Cloud account using the device's unique **attestation token**. This is an action performed in the nRF Cloud portal (or over the REST API).
+- **Provisioning** — Securely installing cloud access credentials onto the device. After claiming, the nRF Provisioning Service delivers these credentials to the device over a DTLS-protected CoAP channel, and the firmware writes them into the modem's secure storage.
+- **Cloud connection** — Establishing a secure CoAP connection from the device to nRF Cloud using the provisioned credentials.
+
+The Asset Tracker Template firmware performs provisioning and cloud connection automatically once the device has been claimed. This page describes how to perform the required user actions (claiming) and how to trigger and reset the flow during development.
 
 <details>
 <summary><strong>What happens during provisioning</strong></summary>
@@ -21,32 +27,32 @@ The Asset Tracker Template uses the <a href="https://docs.nordicsemi.com/bundle/
 <li><strong>Validation</strong>: The device uses the newly provisioned credentials to connect to nRF Cloud CoAP services.</li>
 </ol>
 
-<p>The modem must be offline during credential writing because the modem cannot be connected to the network while data is being written to its storage area (credential writing).
-Therefore it is normal that LTE is disconnected or connected multiple times during provisioning.</p>
+<p>The modem must be offline during credential writing because it cannot be connected to the network while data is being written to its secure storage.
+Therefore, it is normal for LTE to disconnect and reconnect multiple times during provisioning.</p>
 
-<p>The attestation token is different from the JWT - it is used during the initial device claiming process to prove device authenticity to nRF Cloud, not during the provisioning protocol itself.</p>
+<p>The attestation token is different from the JWT — it is used during the initial device claiming process to prove device authenticity to nRF Cloud, not during the provisioning protocol itself.</p>
 
 <p>For more details on the provisioning library, see the <a href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/networking/nrf_provisioning.html">nRF Cloud device provisioning documentation</a>.</p>
 
 </details>
 
-## Manual Provisioning
+## Connecting a device
 
-Provisioning requires actions on both the device and the nRF Cloud portal. First you obtain the attestation token from the device, then you claim the device in nRF Cloud, and finally you wait for the device to complete the provisioning process.
+Connecting a device requires actions on both the device and the nRF Cloud portal. First, you obtain the attestation token from the device, then you claim the device in nRF Cloud, and finally you trigger the device to fetch its credentials.
 
 ### Step 1: Obtain the device attestation token
 
-The attestation token uniquely identifies your device and proves its authenticity to nRF Cloud. You can obtain it in two ways:
+The **attestation token** uniquely identifies your device and proves its authenticity to nRF Cloud. You can obtain it in two ways:
 
-- **Automatic (on first boot)**: When an unprovisioned device boots the Asset Tracker Template firmware for the first time, it prints the attestation token to the serial log. Connect a serial terminal to the device (115200 baud) before powering it on, and look for the token in the output.
+- **Automatic (on first boot)**: When an unprovisioned device boots the Asset Tracker Template firmware for the first time, it prints the attestation token to the serial log. Power the device on, connect a serial terminal (115200 baud) as soon as the USB serial port enumerates, and look for the line labelled `Attestation token:` in the log output. If you missed it, reset the device while the serial terminal is still attached.
 
-- **Manual (using shell command)**: If you missed the token on first boot or need to retrieve it again, run the following AT command in the device shell through the serial terminal:
+- **Manual (using a shell command)**: If you missed the token on first boot or need to retrieve it again, run the following AT command in the device shell through the serial terminal:
 
     ```bash
     at at%attesttoken
     ```
 
-    The token will be printed as a string starting with `%ATTESTTOKEN:`. Copy the entire token value (excluding the `%ATTESTTOKEN:` prefix).
+    The token is printed as a string starting with `%ATTESTTOKEN:`. Copy the entire token value (excluding the `%ATTESTTOKEN:` prefix).
 
 ### Step 2: Claim the device in nRF Cloud
 
@@ -61,7 +67,9 @@ The attestation token uniquely identifies your device and proves its authenticit
     A pop-up opens.
 
 1. Copy and paste the attestation token into the **Claim token** text box.
-1. Set rule to nRF Cloud Onboarding and click **Claim Device**.
+1. Set **Provisioning rule** to **nRF Cloud Onboarding** and click **Claim Device**.
+
+    > **Important:** The **nRF Cloud Onboarding** rule is a named set of provisioning commands stored in your nRF Cloud account. It tells the provisioning service which credentials and configuration to deliver to the device after it is claimed. Selecting the correct rule is required — without it, the device will be claimed but will never receive the credentials needed to connect to nRF Cloud.
 
     <details>
     <summary><strong>If "nRF Cloud Onboarding" rule is not showing:</strong></summary>
@@ -71,22 +79,22 @@ The attestation token uniquely identifies your device and proves its authenticit
     <img src="../images/claim.png" alt="Claim Device" width="300" />
     </details>
 
-### Step 3: Wait for provisioning to complete
+### Step 3: Trigger provisioning on the device
 
-After claiming, the device needs to poll the provisioning service to receive its credentials. This happens automatically, but the device polls at its own interval.
+After claiming, the device must contact the provisioning service to fetch its credentials. To trigger this immediately:
 
-- **Wait**: The device will automatically poll for provisioning commands at its configured interval. This may take a few minutes.
-- **Trigger immediately**: If you want to speed up the process, you can either press and hold **Button 1** on the device or reset it to trigger an immediate provisioning poll.
+- **Thingy:91 X**: Press and hold the button on the top of the device (**Button 1**) for about three seconds.
+- **nRF9151 DK**: Press and hold **Button 1** for about three seconds.
 
-Once the device has received its credentials and connected to nRF Cloud, it will be available under the **Devices** section in the **Device Management** navigation pane on the left.
+The device will poll the provisioning service, receive its credentials, and connect to nRF Cloud over CoAP. Provisioning can take up to a minute. Once complete, the device appears under **Device Management** → **Devices** in the nRF Cloud portal.
 
 > [!NOTE]
 > It is normal for the LTE connection to disconnect and reconnect during provisioning. The modem must go offline temporarily while credentials are written to its secure storage. See the "What happens during provisioning" section at the top of this page for details.
 
 <details>
-<summary><strong>What can you do after provisioning</strong></summary>
+<summary><strong>What can you do after connecting</strong></summary>
 
-<p>After your device is provisioned and connected, you can perform the following:</p>
+<p>After your device is connected to nRF Cloud, you can perform the following:</p>
 
 <p>
 <ul>
@@ -99,15 +107,16 @@ Once the device has received its credentials and connected to nRF Cloud, it will
 </li>
 </ul>
 </p>
-    <details>
-    <summary><strong>Retrieve historical messages</strong></summary>
+<details>
+<summary><strong>Retrieve historical messages</strong></summary>
 
-        ```bash
-        curl -X GET "https://api.nrfcloud.com/v1/messages?device_id=${DEVICE_ID}&pageLimit=10" \
-          -H "Authorization: Bearer ${API_KEY}" \
-          -H "Accept: application/json"
-        ```
-   </details>
+```bash
+curl -X GET "https://api.nrfcloud.com/v1/messages?device_id=${DEVICE_ID}&pageLimit=10" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Accept: application/json"
+```
+
+</details>
 
 <p>
 <ul>
@@ -130,9 +139,7 @@ curl 'https://api.provisioning.nrfcloud.com/v1/claimed-devices' \
 
 ## Reprovisioning
 
-To update device credentials:
-
-In an end product it is recommended to reprovision the device at a reasonable interval depending on the application use case for security reasons.
+Reprovisioning replaces the credentials currently stored on the device. In an end product, it is recommended to reprovision devices at a reasonable interval (depending on the application use case) for security reasons.
 
 ### Manual
 
@@ -165,7 +172,7 @@ For detailed API documentation, see [nRF Cloud REST API](https://api-docs.nrfclo
 
 ## Unclaiming a device
 
-To remove a device from your nRF Cloud account, unclaim the device if it is already associated with another nRF Cloud account before you can associate it with a different account.
+Unclaiming removes a device from your nRF Cloud account. If a device is already claimed on another account, it must be unclaimed there before it can be claimed on a different account.
 
 ### Manual
 

--- a/docs/common/customization.md
+++ b/docs/common/customization.md
@@ -659,7 +659,7 @@ The following are some of the available options for controlling the MQTT module:
     [00:01:19.350,921] <dbg> mqtt_helper: mqtt_evt_handler: MQTT_EVT_PINGRESP
     ```
 
-### **Module State Machine**
+### Module state machine
 
 The cloud MQTT module implements an internal state machine to manage the connection and reconnection logic.
 

--- a/docs/common/fota.md
+++ b/docs/common/fota.md
@@ -60,7 +60,7 @@ To verify a successful update:
 
 ## Performing FOTA updates
 
-You can update the FOTA updates using nRF Cloud Web UI or REST API.
+You can perform FOTA updates using the nRF Cloud Web UI or the REST API.
 
 ### Option 1: nRF Cloud Web UI
 
@@ -68,40 +68,45 @@ This is the recommended method for manual updates and testing.
 
 1. Navigate to [nRF Cloud](https://nrfcloud.com) and log in to your account.
 1. Select **Firmware Updates** in the **Device Management** tab on the left.
-1. Create Update Bundle:
+1. Create an update bundle:
 
-    1. Click on "Add bundle".
+    1. Click **Add bundle**.
     1. Upload your bundle file:
 
         - For application updates: `dfu_application.zip`
         - For bootloader updates: `dfu_mcuboot.zip`
 
-    1. Set **Update Type** (for example, LTE).
     1. Enter a **Name** for the bundle.
     1. Enter a **Version** string (this is only a label for the bundle list and is not used by the device).
     1. Click **Create/Upload Bundle**.
 
-1. Create FOTA Update:
+1. Create a FOTA update:
 
-    1. Click on "Create FOTA update"
-    1. Enter a **Name** and a **Description** of the update.
-    1. Select target device(s) through device or group selection.
-    1. Click on **Deploy now**.
     1. Click **Create FOTA Update**.
+    1. Enter a **Name** for the update.
+    1. Optionally enter a **Description**.
+    1. In the **Bundle** dropdown, select the bundle you uploaded in the previous step. The update type is determined by the bundle, so no separate type selector is required.
+    1. Select the target device or devices using one of the following fields:
 
-1. Monitor Progress:
+        - **Group** — deploys to every device in a predefined device group.
+        - **Devices** — pick individual devices by clicking their device UUID to add them to the selection.
 
-    - The **Overall Progress** section will go from **In Progress** to **Completed**.
-    - The individual device **Status** will progress: **Queued → Updating → Succeeded**.
-    - The device will automatically download and apply the update once it becomes online.
-    - To trigger an immediate FOTA poll, press and hold **Button 1** on the device.
+    1. Check **Deploy now** to start the update immediately after creation. Leave it unchecked to create the job and deploy it manually later.
+    1. Click **Create FOTA Update** to create the update.
 
-1. Verify Update:
+1. Monitor progress:
 
-    1. Navigate to your device page, click **Devices** under **Device Management** in the navigation pane on the left, and select your device
-    1. Click on **Device info** under the **Device Information** card.
+    - The **Overall Progress** section transitions from **In Progress** to **Completed**.
+    - The individual device **Status** progresses through **Queued → Updating → Succeeded**.
+    - The device automatically downloads and applies the update once it comes online.
+    - To trigger an immediate FOTA poll, press and hold **Button 1** on the device. On **Thingy:91 X**, pressing on the top of the case pushes Button 1.
+
+1. Verify the update:
+
+    1. Navigate to your device page: click **Devices** under **Device Management** in the navigation pane on the left, then click the device UUID in the list to open the device page.
+    1. Click **Device info** under the **Device Information** card.
     1. Check the **App Version** (for app updates) or **Modem Firmware** (for modem updates) field.
-    1. Confirm the version matches your new firmware.
+    1. Confirm that the version matches your new firmware.
 
 ### Option 2: REST API
 
@@ -116,7 +121,7 @@ export DEVICE_ID=<your-device-id>
 
 Find your API key in **User Account** settings in [nRF Cloud](https://nrfcloud.com/). See [nRF Cloud REST API](https://api.nrfcloud.com/) for reference.
 
-#### Complete Update Workflow
+#### Complete update workflow
 
 1. Create manifest and upload bundle:
 
@@ -183,7 +188,7 @@ Find your API key in **User Account** settings in [nRF Cloud](https://nrfcloud.c
 
 1. Verify the update by checking the device information in [nRF Cloud](https://nrfcloud.com/) (**App Version** or **Modem Firmware** field).
 
-#### API Reference
+#### API reference
 
 **List FOTA jobs**:
 

--- a/docs/common/getting_started.md
+++ b/docs/common/getting_started.md
@@ -8,18 +8,6 @@ There are two options for setting up the project, depending on your preferred de
 
 For pre-built binaries that do not require a build environment, refer to the latest tag and the [release artifacts](release.md) documentation.
 
-## Supported boards
-
-The Asset Tracker Template is continuously verified in CI on the following boards:
-
-- **[Thingy:91 X](https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91-X)**
-
-    - Build target `thingy91x/nrf9151/ns`
-
-- **[nRF9151 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF9151-DK)**
-
-    - Build target `nrf9151dk/nrf9151/ns`
-
 ## Option 1: nRF Connect for VS Code (Recommended)
 
 1. In nRF Connect for VS Code, the Asset Tracker Template is available as an add-on in the **Create New Application** menu:
@@ -30,9 +18,53 @@ The Asset Tracker Template is continuously verified in CI on the following board
 
     ![Asset Tracker Template add-on](../images/addon_att.png)
 
-1. Once you have created the project, you can access various development actions through the **Actions** panel in the nRF Connect for VS Code. These actions provide quick access to common tasks such as building, flashing, and debugging your application:
+1. Once the project is created, it appears under **Applications** in the nRF Connect for VS Code side panel. Click **Add build configuration** under the **app** entry (or use the **Add Build Configuration** button under **Build**) to open the build configuration dialog.
 
-    ![Extension actions](../images/actions.png)
+1. In the **Add Build Configuration (app)** dialog, set **Board target**. With the **Compatible** filter selected (the default), only the supported build targets are listed:
+
+    | Board        | Board target            |
+    | ------------ | ----------------------- |
+    | Thingy:91 X  | `thingy91x/nrf9151/ns`  |
+    | nRF9151 DK   | `nrf9151dk/nrf9151/ns`  |
+
+    Leave the other fields at their defaults and click **Generate and Build** to build the application.
+
+1. After the build completes, the **Actions** panel is populated with options such as **Build**, **Flash**, **Debug**, **nRF Kconfig GUI**, and **Memory report**. Use these to flash, debug, and reconfigure the application.
+
+> [!NOTE]
+> The built-in **Flash** action programs the device through an external debugger. **Thingy:91 X** does not have an on-board debugger, so without an external J-Link attached you need to flash it over the serial bootloader instead. From a terminal in the toolchain environment:
+>
+> 1. List connected devices to find the Thingy:91 X serial number:
+>
+>     ```shell
+>     nrfutil device list
+>     ```
+>
+>     In the output, locate the entry with **Product: `Thingy:91 X UART`** and the **`mcuBoot`** trait. Its identifier (for example `THINGY91X_ED0E7655C09`) is the serial number to use in the next step:
+>
+>     ```
+>     851006699
+>     Product         J-Link
+>     Traits          usb, jlink, seggerUsb
+>
+>     THINGY91X_ED0E7655C09       <-- this is the Thingy:91 X serial number
+>     Product         Thingy:91 X UART
+>     Ports           /dev/tty.usbmodem142102, vcom: 0
+>                     /dev/tty.usbmodem142105, vcom: 1
+>     Traits          mcuBoot, modem, serialPorts, nordicUsb, usb
+>     ```
+>
+> 2. Flash the application using one of the following commands:
+>
+>     ```shell
+>     # Using west (recommended)
+>     west thingy91x-dfu
+>
+>     # Or using nRF Util directly, replacing <serial-number> with the value from step 1
+>     nrfutil device program --firmware build/dfu_application.zip \
+>         --serial-number <serial-number> --traits mcuboot \
+>         --x-family nrf91 --core Application
+>     ```
 
 For more details on how to use the nRF Connect for VS Code, refer to the [nRF Connect for VS Code documentation](https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/index.html).
 
@@ -59,18 +91,18 @@ For more details on how to use the nRF Connect for VS Code, refer to the [nRF Co
 Before initializing, start the toolchain environment:
 
 ```shell
-nrfutil sdk-manager toolchain launch --ncs-version v3.0.0 --shell
+nrfutil sdk-manager toolchain launch --ncs-version v3.1.0 --shell
 ```
 
-Alternatively, you can run the command with a specific nRF Connect SDK version. For example, if you are using version 3.0.1, run:
+You can also run a single command within a specific nRF Connect SDK toolchain. For example:
 
 ```shell
-nrfutil sdk-manager toolchain launch --ncs-version v3.0.0 -- <your command>
+nrfutil sdk-manager toolchain launch --ncs-version v3.1.0 -- <your command>
 ```
 
-To run, for instance the `west` command with the specified version of the toolchain. You can create an alias or shell function for this command to avoid typing it in full every time.
+This form is useful for running, for instance, a single `west` command with a specific toolchain. You can create an alias or shell function for this command to avoid typing it in full every time.
 
-In this document, the `nrfutil toolchain-manager launch --shell` variant is used to launch the toolchain environment in the shell.
+In this document, the `nrfutil sdk-manager toolchain launch --shell` variant is used to launch the toolchain environment in the shell.
 
 To initialize the workspace folder (`asset-tracker-template`) where the firmware project and all nRF Connect SDK modules will be cloned, run the following commands:
 
@@ -88,7 +120,7 @@ The template repository is now cloned into the `asset-tracker-template` folder, 
 
 ### Building and running
 
-Complete the following steps for building and running using command line:
+Complete the following steps to build and run the application from the command line:
 
 1. Navigate to the application folder:
 
@@ -97,16 +129,46 @@ Complete the following steps for building and running using command line:
     cd project/app
     ```
 
-1. To build the application, run the following command:
+1. Build the application by passing the corresponding build target to `west build`:
 
     ```shell
-    west build -p -b thingy91x/nrf9151/ns # Pristine build
+    # Thingy:91 X
+    west build -p -b thingy91x/nrf9151/ns
+
+    # nRF9151 DK
+    west build -p -b nrf9151dk/nrf9151/ns
     ```
 
-1. When using the serial bootloader on Thingy:91 X, you can update the application using the following command:
+1. When using the serial bootloader on Thingy:91 X (the default, since Thingy:91 X has no on-board debugger), first list connected devices to find the Thingy:91 X serial number:
 
     ```shell
+    nrfutil device list
+    ```
+
+    In the output, locate the entry with **Product: `Thingy:91 X UART`** and the **`mcuBoot`** trait. Its identifier (for example `THINGY91X_ED0E7655C09`) is the serial number used in the flashing command below:
+
+    ```
+    851006699
+    Product         J-Link
+    Traits          usb, jlink, seggerUsb
+
+    THINGY91X_ED0E7655C09       <-- this is the Thingy:91 X serial number
+    Product         Thingy:91 X UART
+    Ports           /dev/tty.usbmodem142102, vcom: 0
+                    /dev/tty.usbmodem142105, vcom: 1
+    Traits          mcuBoot, modem, serialPorts, nordicUsb, usb
+    ```
+
+    Then flash the application using one of the following commands:
+
+    ```shell
+    # Using west (recommended)
     west thingy91x-dfu
+
+    # Or using nRF Util directly, replacing <serial-number> with the value from nrfutil device list
+    nrfutil device program --firmware build/dfu_application.zip \
+        --serial-number <serial-number> --traits mcuboot \
+        --x-family nrf91 --core Application
     ```
 
 1. When using nRF9151 DK or an external debugger on Thingy:91 X, you can program the device using the following command:
@@ -117,26 +179,11 @@ Complete the following steps for building and running using command line:
 
 The application is now built and flashed to the device. You can open a serial terminal to see the logs from the application. The default baud rate is 115200. It is recommended to use the Serial Terminal app, which you can install from [nRF Connect for Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop). You can also use other serial terminal applications like PuTTY, Tera Term, or minicom.
 
-### Building with overlays
+## Connect device to nRF Cloud
 
-You can build the application with different overlays to enable or disable certain features. The following are some examples of how to build the application with different overlays.
+To connect to [nRF Cloud](https://nrfcloud.com), the device must be claimed on your account and provisioned with the correct credentials. Follow the detailed steps in the [Connecting](connecting.md) documentation.
 
-Debug build with Memfault:
-
-```shell
-west build -p -b thingy91x/nrf9151/ns -- -DEXTRA_CONF_FILE="overlay-memfault.conf;overlay-upload-modem-traces-to-memfault.conf"
-```
-
-> Note: By default, Memfault data is routed via CoAP to the Memfault project linked to your provisioned nRF Cloud account (see below for provisioning steps). To override this, set `CONFIG_MEMFAULT_NCS_PROJECT_KEY="YOUR_PROJECT_KEY"`.
-
-## Provision device to nRF Cloud
-
-To connect to [nRF Cloud](https://nrfcloud.com), the device must be provisioned to your account. You can provision the device using one of the following methods:
-
-* **Quickstart application**: Use the [Quick Start app](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html) in the [nRF Connect for Desktop](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-desktop) for a streamlined setup process.
-* **Manual provisioning**: Follow the detailed steps in the [Provisioning](provisioning.md) documentation.
-
-The provisioning process establishes the necessary credentials and certificates for secure communication between your device and nRF Cloud.
+The connection flow establishes the credentials and certificates required for secure communication between your device and nRF Cloud.
 
 ## Testing
 
@@ -146,16 +193,13 @@ To test that everything is working as expected, complete the following steps:
 
     ![nRF Cloud device management menu](../images/nrfcloud_devices.png)
 
-1. After provisioning, the device must already be connected and sending data. In the web browser, you will see the device page updating with the latest information from the device, including the location, battery level, and other sensor data.
+1. After provisioning, the device should already be connected and sending data. In the web browser, you will see the device page update with the latest information from the device, including the location, battery level, and other sensor data.
 
     ![nRF Cloud example data](../images/nrf_cloud_example_data.png)
 
-1. Press and hold **Button 1** on the device to trigger an immediate cloud sync, including sending buffered data, polling for FOTA updates, and fetching configuration changes.
+1. Press and hold **Button 1** on the device to trigger an immediate cloud sync, including sending buffered data, polling for FOTA updates, and fetching configuration changes. On **Thingy:91 X**, pressing on the top of the case pushes Button 1.
 
     > **Note:** The device samples and sends data at configurable intervals. Between intervals, the device is in a low-power state. Pressing and holding the button forces an immediate cloud update cycle.
-    <blockquote>
-    <strong>NOTE:</strong> The device samples and sends data at configurable intervals. Between intervals, the device is in a low-power state. Pressing and holding the button forces an immediate cloud update cycle.
-    </blockquote>
 
 1. Optionally, you can reset the device to observe the full boot and connection sequence. Connect to the device using the serial terminal and reset the device using either the reset button or the following shell command:
 

--- a/docs/common/low_power.md
+++ b/docs/common/low_power.md
@@ -40,7 +40,7 @@ CONFIG_LTE_PSM_REQ_RAT_SECONDS=60      # Active Time: 1 minute
 
 It is recommended to configure a periodic TAU timer longer than the update interval of the application to avoid synchronization with the network between updates.
 
-See [Configuration guide - PSM](configuration.md#psm-power-saving-mode) for additional options. The actual values are negotiated with the network.
+See the [Configuration guide — PSM](configuration.md#power-saving-mode-psm) for additional options. The actual values are negotiated with the network.
 
 ### Extended Discontinuous Reception (eDRX)
 
@@ -55,17 +55,17 @@ eDRX is used to periodically sleep during the PSM active timer. With the default
 
 ### Update interval
 
-The following Kconfig options that are set in the `prj.conf` file control sampling and transmission frequency:
+The following Kconfig options set in the `prj.conf` file control sampling and transmission frequency:
 
 ```config
-CONFIG_APP_SAMPLING_INTERVAL_SECONDS=150    # Default: 2.5 minutes
-CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS=600            # Default: 10 minutes
-CONFIG_APP_STORAGE_INITIAL_THRESHOLD=1 # Default: 1 item
+CONFIG_APP_SAMPLING_INTERVAL_SECONDS=600      # Default: 10 minutes
+CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS=3600 # Default: 1 hour
+CONFIG_APP_STORAGE_INITIAL_THRESHOLD=1        # Default: 1 item
 ```
 
-Sensors and location are sampled and stored at every interval set in the `CONFIG_APP_SAMPLING_INTERVAL_SECONDS` Kconfig option and sent to the cloud at every interval as set in the `CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS` Kconfig option or when the number of stored items reaches the `CONFIG_APP_STORAGE_INITIAL_THRESHOLD` threshold.
+Sensors and location are sampled and stored at the interval set by the `CONFIG_APP_SAMPLING_INTERVAL_SECONDS` Kconfig option, and sent to the cloud at the interval set by the `CONFIG_APP_CLOUD_UPDATE_INTERVAL_SECONDS` Kconfig option or when the number of stored items reaches the `CONFIG_APP_STORAGE_INITIAL_THRESHOLD` threshold.
 
-You can adjust these Kconfig options at runtime using the nRF Cloud device shadow. See [Configuration guide](configuration.md#set-sampling-interval-and-logic-from-cloud) for details.
+You can adjust these values at runtime using the nRF Cloud device shadow. See the [Configuration guide](configuration.md#runtime-configurations) for details.
 
 **Impact:** Using longer intervals between operations and increasing the storage threshold results in fewer network connections and leads to lower power consumption.
 

--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -12,7 +12,7 @@ For more knowledge on debugging and troubleshooting [nRF Connect SDK](https://gi
 
 The template provides several shell commands for controlling and monitoring device behavior. Connect to the device's UART interface using either:
 
-- [Serial terminal app](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) form nRF Connect for Desktop.
+- [Serial terminal app](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) from nRF Connect for Desktop.
 - Your preferred terminal application (for example, `putty`, `minicom`, `terraterm`).
 
 ### Available Commands
@@ -79,8 +79,7 @@ uart:~$ att_cloud provision
 [00:00:45.290,954] <wrn> cloud: Treating as provisioning finished
 ```
 
-When the provisioning command is called, the device will connect to the provisioning endpoint and check if there are any pending commands for the device
-and execute them if any. You can use it to reprovision the device for development purposes and when it is desired to swap out the certificates used in the CoAP connection.
+When the provisioning command is called, the device connects to the provisioning endpoint, checks for any pending commands for the device, and executes them if present. Use this command to reprovision the device during development, or when you want to swap out the credentials used in the CoAP connection.
 
 #### Network disconnect
 
@@ -162,14 +161,13 @@ CONFIG_TRACING=y
 CONFIG_SEGGER_SYSTEMVIEW=y
 ```
 
-And build or flash the template for the respective board.
-Or build with the necessary configurations passed in via the west build command:
+Then build and flash the template for the target board, or pass the configurations directly on the `west build` command line:
 
 ```bash
 west build -p -b <board> -- -DCONFIG_TRACING=y -DCONFIG_SEGGER_SYSTEMVIEW=y
 ```
 
-Or RTT tracing snippet:
+Alternatively, use the RTT tracing snippet:
 
 ```bash
 west build -p -b <board> -- -Dapp_SNIPPET=rtt-tracing
@@ -246,7 +244,7 @@ For more information, see [Zephyr Thread Analyzer](https://docs.zephyrproject.or
 
 ### Hardfaults
 
-When a hardfault occurs, you can check the [LR and PC](https://stackoverflow.com/questions/8236959/what-are-sp-stack-and-lr-in-arm) registers in order to find the offending instruction.
+When a hardfault occurs, you can check the [LR and PC](https://stackoverflow.com/questions/8236959/what-are-sp-stack-and-lr-in-arm) registers to find the offending instruction.
 For example, in this fault frame the PC is `0x00002681`, thread is `main` and type of error is a stack overflow.
 So in this case, there is no need to look up the PC or LR to understand the issue.
 The main stack size needs to be increased.
@@ -272,9 +270,9 @@ For more information on how to debug hardfaults, see [Memfault Cortex Hardfault 
 [00:00:00.897,583] <err> os: Halting system
 ```
 
-However, if the fault source is more ambiguous it might be needed to use `Address-2-Line` to lookup the offending function.
-In this example, the LR address is used to find the function address stored in the LR register.
-This function is the parent in the callstack of the address the PC points to.
+However, if the fault source is more ambiguous, you might need to use `addr2line` to look up the offending function.
+In this example, the LR address is used to find the function stored in the LR register.
+That function is the caller in the callstack of the address the PC points to.
 
 ```bash
 <path-to-zephyr-sdk>/arm-zephyr-eabi/bin/arm-zephyr-eabi-addr2line -e build/app/zephyr/zephyr.elf 0x0007b6f7
@@ -322,7 +320,7 @@ Here is some context for the exception:
     SFAR: 0x00000000
 ```
 
-Here we can again lookup the PC and LR in the non-Secure image to find the offending function:
+Here we can again look up the PC and LR in the non-secure image to find the offending function:
 
 ```bash
 ~/dev/projects/att/Asset-Tracker-Template/app add-sensor-docs *18 !5 ❯ a2l 0x0003D7B6
@@ -335,7 +333,7 @@ Secure faults will display:
 - Non-secure SP and LR registers.
 - Violation details.
 
-For more information, refer the following documentation:
+For more information, refer to the following documentation:
 
 - [TF-M Documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/tfm/introduction/readme.html#repositories)
 - [nRF Connect SDK TF-M Guide](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/security/tfm/index.html)
@@ -348,7 +346,7 @@ For more information, refer the following documentation:
 > CONFIG_RESET_ON_FATAL_ERROR=n
 > ```
 
-When enabling immediate logging, it might be necessary to increase the stack size of certain threads due to logging being executed in context which increases stack usage.
+When enabling immediate logging, it might be necessary to increase the stack size of certain threads, because log messages are emitted in the calling thread's context, which increases stack usage.
 
 ### State Inspection Script
 
@@ -435,9 +433,9 @@ backoff_time        : 60 (0x3C)
 ## Memfault Remote Debugging
 
 The template supports remote debugging using [Memfault](https://memfault.com/).
-Remote debugging enables the device to send metrics suchs as LTE, GNSS and memory statistics as well as coredump captures on crashes to analyse problems across single or fleet of devices once they occur.
+Remote debugging enables the device to send metrics such as LTE, GNSS, and memory statistics, as well as coredump captures on crashes, to analyse problems across single devices or a fleet of devices once they occur.
 
-For more information see the following documenation:
+For more information, see the following documentation:
 
 - [Memfault Sample](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/debug/memfault/README.html)
 - [Memfault Integration](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/debug/memfault_ncs.html)
@@ -506,8 +504,8 @@ Screen capture from a coredump received in Memfault:
 ![Memfault UI](../images/memfault.png)
 
 > [!IMPORTANT]
-> In order to properly use Memfault and be able to decode metrics and coredumps sent from the device, you need to upload the ELF file located in the build folder of the template once you have built the application.
-> This is covered in the [Remote Debugging with Memfault](https://academy.nordicsemi.com/courses/nrf-connect-sdk-intermediate/lessons/lesson-2-debugging/topic/exercise-4-remote-debugging-with-memfault/) developer Academy excersise.
+> To properly use Memfault and decode the metrics and coredumps sent from the device, you need to upload the ELF file located in the build folder of the template once you have built the application.
+> This is covered in the [Remote Debugging with Memfault](https://academy.nordicsemi.com/courses/nrf-connect-sdk-intermediate/lessons/lesson-2-debugging/topic/exercise-4-remote-debugging-with-memfault/) Developer Academy exercise.
 
 #### Test shell commands
 
@@ -542,14 +540,14 @@ nrfutil trace lte --input-serialport /dev/tty.usbmodem141405 --output-pcapng tra
 ⠒ Saving trace to trace.pcapng (11952 bytes)
 ```
 
-If not traces are captured it might be needed to reset the device.
-After capturing the trace it can be opened in wireshark:
+If no traces are captured, it might be necessary to reset the device.
+After capturing, the trace can be opened in Wireshark:
 
 ```bash
 wireshark trace.pcapng
 ```
 
-You can also do live tracing by piping the traces to wireshark:
+You can also do live tracing by piping the traces to Wireshark:
 
 ```bash
 nrfutil trace lte --input-serialport /dev/tty.usbmodem141405 --output-pcapng trace.pcapng --output-wireshark wireshark
@@ -685,4 +683,4 @@ For more information, see [nRF Connect SDK Modem Tracing](https://docs.nordicsem
 
 ## Common Issues and Solutions
 
-If you are not able to resolve the issue with the tools and instructions given in this documentation, it's recommended to create an issue in the [template repository](https://github.com/nrfconnect/Asset-Tracker-Template/issues) or register a support ticket in [Nordic's support portal](https://devzone.nordicsemi.com/).
+If you are not able to resolve the issue with the tools and instructions given in this documentation, it is recommended to create an issue in the [template repository](https://github.com/nrfconnect/Asset-Tracker-Template/issues) or register a support ticket in [Nordic's support portal](https://devzone.nordicsemi.com/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,9 @@ Use the [nRF Connect for VS Code](https://docs.nordicsemi.com/bundle/nrf-connect
 3. Select **Create New Application**.
 4. Select **Browse nRF Connect SDK add-on Index**.
 5. Search for **Asset Tracker Template** and create the project.
-6. Use the **Actions** panel in the extension to build and flash the application.
+6. In the **Applications** side panel, click **Add build configuration** under **app**.
+7. In the **Add Build Configuration (app)** dialog, set **Board target** to one of the supported build targets — `thingy91x/nrf9151/ns` (Thingy:91 X) or `nrf9151dk/nrf9151/ns` (nRF9151 DK). With the **Compatible** filter selected, only the supported targets are listed.
+8. Click **Generate and Build**, then use the **Actions** panel to flash and debug the application.
 
 ### Option 2: Command line
 
@@ -84,19 +86,27 @@ west flash --erase
 
 For more details, see the [Getting Started Guide](common/getting_started.md).
 
-### Provision device to nRF Cloud
+### Connect device to nRF Cloud
 
-After building and flashing (using either option above), you need to provision the device to connect to [nRF Cloud](https://nrfcloud.com).
+After building and flashing (using either option above), connect the device to [nRF Cloud](https://nrfcloud.com). This involves three steps:
+
+- **Claiming** — registering the device with your nRF Cloud account using the attestation token.
+- **Provisioning** — the device securely receives cloud credentials from the nRF Provisioning Service.
+- **Cloud connection** — the device establishes a CoAP connection to nRF Cloud using the provisioned credentials.
 
 <details>
-<summary><strong>Provisioning steps</strong></summary>
+<summary><strong>Connecting</strong></summary>
 <ol>
 <li>Get the device attestation token. Open a serial terminal connected to the device (115200 baud) and run the following AT command in the device shell:
 <pre><code class="language-bash">at at%attesttoken</code></pre>
-The token is also printed automatically to the serial log on first boot of unprovisioned devices.</li>
+The token is also printed automatically to the serial log on first boot of unprovisioned devices, labelled <code>Attestation token:</code>.</li>
 <li>Log in to the <a href="https://nrfcloud.com">nRF Cloud</a> portal.</li>
 <li>Navigate to <strong>Security Services</strong> → <strong>Claimed Devices</strong> → <strong>Claim Device</strong>.</li>
-<li>Paste the attestation token, set rule to "nRF Cloud Onboarding", and click <strong>Claim Device</strong>.</li>
+<li>Paste the attestation token, set <strong>Provisioning rule</strong> to <strong>nRF Cloud Onboarding</strong>, and click <strong>Claim Device</strong>.</li>
+</ol>
+
+> [!IMPORTANT]
+> The **nRF Cloud Onboarding** rule is the named set of provisioning commands that tells nRF Cloud which credentials to deliver to the device. Selecting the correct rule is required.
 
 <details>
 <summary><strong>If "nRF Cloud Onboarding" rule is not showing:</strong></summary>
@@ -106,10 +116,14 @@ Create a new rule using the following configuration:<br>
 <img src="images/claim.png" alt="Claim Device" width="300" />
 </details>
 
-<li>After claiming, wait for the device to provision credentials and connect to nRF Cloud over CoAP. Once connected, the device will be available under <strong>Device Management</strong> → <strong>Devices</strong>. If you want a quicker response, press and hold <strong>Button 1</strong> on the device or reset it to trigger an immediate provisioning poll.</li>
+<ol start="5">
+<li>Press and hold <strong>Button 1</strong> on the device for a couple of seconds to trigger provisioning. On <strong>Thingy:91 X</strong>, pressing on the top of the case pushes Button 1.
+
+Once provisioning completes, the device appears under <strong>Device Management</strong> → <strong>Devices</strong>.
+</li>
 </ol>
 
-See <a href="common/provisioning.md">Provisioning to nRF Cloud</a> for more details.
+See <a href="common/connecting.md">Connecting to nRF Cloud</a> for more details.
 
 </details>
 

--- a/docs/modules/location.md
+++ b/docs/modules/location.md
@@ -61,7 +61,7 @@ enum location_msg_type {
 
 ## Configurations
 
-Several Kconfig options in `Kconfig.location` control this module's behavior. The following configuration parameters are associated with this module::
+Several Kconfig options in `Kconfig.location` control this module's behavior. The following configuration parameters are associated with this module:
 
 - **CONFIG_APP_LOCATION:**
   Enables the location module. Automatically selected if **CONFIG_LOCATION** is enabled.

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -66,22 +66,22 @@ This module allocates RAM from the following places, and understanding these hel
 
 - Shrink batch pipe buffer
 
-    - Set the `CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE` Kconfig option to a low value (for example,
-      from 64 to 256 bytes), but ensure it can hold at least one item of `sizeof(header) +
-      max_item_size` if you use batch mode.
+    - Set the `CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE` Kconfig option to a lower value (for example,
+      from 1024 down to 256 bytes), but ensure it can still hold at least one item of
+      `sizeof(header) + max_item_size` if you use batch mode.
 
 - Reduce thread and queues
 
-    - Set the `CONFIG_APP_STORAGE_THREAD_STACK_SIZE` Kconfig option to a lower value (for example, from 2048 to 1024), if your application leaves headroom.
-    - Reduce relevant zbus queue sizes in system config if traffic allows.
+    - Set the `CONFIG_APP_STORAGE_THREAD_STACK_SIZE` Kconfig option to a lower value (for example, from 2048 down to 1024) if your application leaves headroom.
+    - Reduce the relevant zbus queue sizes in the system configuration if traffic allows.
 
 - Remove development features
 
     - Disable the `CONFIG_APP_STORAGE_SHELL` and `CONFIG_APP_STORAGE_SHELL_STATS` Kconfig option to trim RAM and code footprint.
 
-- Prefer LittleFS backend when buffering many records
+- Prefer the LittleFS backend when buffering many records
 
-    - Use the littleFS backend when large value `CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE` is needed, since the RAM backend allocates all ring buffers at boot, while the littleFS backend only needs RAM for the currently stored records.
+    - Use the LittleFS backend when a large `CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE` value is needed, because the RAM backend allocates all ring buffers at boot, while the LittleFS backend only uses RAM for the currently stored records.
 
 - Ready-made Kconfig fragment
 
@@ -89,7 +89,7 @@ This module allocates RAM from the following places, and understanding these hel
 
 #### Minimal RAM example
 
-If your application will only ever operate with immediate sending (`CONFIG_APP_STORAGE_THRESHOLD=1`) the following `prj.conf` excerpt minimizes RAM usage for the storage module.
+If your application only needs immediate sending (`CONFIG_APP_STORAGE_INITIAL_THRESHOLD=1`), the following `prj.conf` excerpt minimizes RAM usage for the storage module.
 
 ```config
 # Minimal storage configuration
@@ -107,8 +107,7 @@ CONFIG_APP_STORAGE_SHELL_STATS=n
 ```
 
 > [!NOTE]
->
-> - For RAM backend the actual RAM consumed by ring buffers scales with which data types are enabled and the value of the `CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE` Kconfig option.
+> For the RAM backend, the actual RAM consumed by the ring buffers scales with which data types are enabled and the value of the `CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE` Kconfig option.
 
 ### Flash management (LittleFS backend)
 
@@ -142,7 +141,7 @@ Choose a partition size that meets or exceeds `flash_size`. The LittleFS partiti
 If the requirement is not met, either increase the partition (`CONFIG_PM_PARTITION_SIZE_LITTLEFS` or DTS partition size) or reduce storage pressure (fewer records, smaller data types, or fewer enabled types).
 
 > [!NOTE]
-> The data types are stored in separate files, so the minimum amount of flash blocks needed are ∑ data type + 3.
+> The data types are stored in separate files, so the minimum number of flash blocks needed is ∑ data types + 3.
 
 #### Target-specific defaults
 
@@ -195,21 +194,20 @@ To further optimize flash lifespan:
 
 The following sections showcase various configuration examples.
 
-##### Basic littleFS configuration
+##### Basic LittleFS configuration
 
 To enable persistent flash storage:
 
 ```config
 CONFIG_APP_STORAGE=y
 CONFIG_APP_STORAGE_BACKEND_LITTLEFS=y
-CONFIG_APP_STORAGE_INITIAL_MODE_BUFFER=y
 
 # Configure partition size (default is 64 KB)
 CONFIG_PM_PARTITION_SIZE_LITTLEFS=0x10000
 
 # Adjust for your needs
 CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE=16
-CONFIG_APP_STORAGE_THREAD_STACK_SIZE=3000
+CONFIG_APP_STORAGE_THREAD_STACK_SIZE=4000
 ```
 
 ##### Optimized for data persistence with minimal flash wear
@@ -218,14 +216,12 @@ CONFIG_APP_STORAGE_THREAD_STACK_SIZE=3000
 # Storage enabled with persistent backend
 CONFIG_APP_STORAGE=y
 CONFIG_APP_STORAGE_BACKEND_LITTLEFS=y
-CONFIG_APP_STORAGE_INITIAL_MODE_BUFFER=y
 
 # Larger partition distributes writes across more flash blocks
 CONFIG_PM_PARTITION_SIZE_LITTLEFS=0x20000
 
 # Higher record count reduces rewrite frequency
 CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE=50
-
 ```
 
 ## Messages
@@ -320,7 +316,7 @@ The following includes the key configuration categories:
 - **CONFIG_APP_STORAGE_MAX_TYPES** (default: `3`): Maximum number of different data types that can be registered.
   Affects RAM usage.
 
-- **CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE** (default: `8`): Maximum records stored per data type.
+- **CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE** (default: `8` for the RAM backend, `64` for the LittleFS backend): Maximum records stored per data type.
   Total RAM usage = `MAX_TYPES` × `MAX_RECORDS_PER_TYPE` × `RECORD_SIZE`.
 
 - **CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE** (default: `1024`): Size of the internal buffer for batch data access.
@@ -340,7 +336,7 @@ The following includes the key configuration categories:
 
 ### Thread configuration
 
-- **CONFIG_APP_STORAGE_THREAD_STACK_SIZE** (default: `1536`): Stack size for the storage module's main thread.
+- **CONFIG_APP_STORAGE_THREAD_STACK_SIZE** (default: `2048` for the RAM backend, `4000` for the LittleFS backend): Stack size for the storage module's main thread.
 
 - **CONFIG_APP_STORAGE_WATCHDOG_TIMEOUT_SECONDS** (default: `60`): Watchdog timeout for detecting stuck operations.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ nav:
   - Architecture: common/architecture.md
   - Configuration: common/configuration.md
   - Customization: common/customization.md
-  - Provisioning: common/provisioning.md
+  - Connecting: common/connecting.md
   - Location services: common/location_services.md
   - Achieving low power: common/low_power.md
   - Firmware Updates (FOTA): common/fota.md


### PR DESCRIPTION
- Rename `docs/common/provisioning.md` to `docs/common/connecting.md` to make it clear how to get connected to nRF Cloud.
- General cleanup and clarify docs.
- Improve `cloud_provisioning.c` attestation token log format: wrap token in `BEGIN`/`END` delimiter lines for easier copy-paste, and label it `Attestation token:`
- Add `app/sample.yaml` with CI build configuration for `thingy91x/nrf9151/ns` and `nrf9151dk/nrf9151/ns` to get the boards listed in `compatible boards` when building with the extension.