### PR TITLE
west.yml: bump nrf SDK revision to v3.3.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v3.3.0-rc2
+      revision: v3.3.0
       import: true


### PR DESCRIPTION
Update `revision` from `v3.3.0-rc2` to `v3.3.0` (final release).