### PR TITLE
docs: remove pre-built firmware download mention from README and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ If you are new to nRF91 series and cellular IoT, consider taking the [Nordic Dev
 
 To set up your development environment, build the application, flash it to your device, and connect it to [nRF Cloud](https://nrfcloud.com), follow the [Getting Started](docs/common/getting_started.md) guide.
 
-If you do not need a build environment, you can download pre-built firmware binaries from the [latest release](https://github.com/nrfconnect/Asset-Tracker-Template/releases) and flash them directly to your device. See the [release artifacts](docs/common/release.md) documentation for details.
-
 ---
 
 ## Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,6 @@ If you are new to nRF91 series and cellular IoT, consider taking the [Nordic Dev
 
 To set up your development environment, build the application, flash it to your device, and connect it to [nRF Cloud](https://nrfcloud.com), follow the [Getting Started](common/getting_started.md) guide.
 
-If you do not need a build environment, you can download pre-built firmware binaries from the [latest release](https://github.com/nrfconnect/Asset-Tracker-Template/releases) and flash them directly to your device. See the [release artifacts](common/release.md) documentation for details.
-
 ## System Overview
 
 ![System overview](images/system_overview.svg)


### PR DESCRIPTION
Remove the paragraph referencing pre-built firmware binaries and the link to release artifacts from both `README.md` and `docs/index.md`.