### PR TITLE
app: zcbor: use unordered maps for device shadow

### DIFF
--- a/app/src/cbor/CMakeLists.txt
+++ b/app/src/cbor/CMakeLists.txt
@@ -17,13 +17,17 @@ configure_file(
 
 # Generate encoder and decoder code using zcbor
 set(zcbor_command
-        zcbor code # Invoke code generation
+	${PYTHON_EXECUTABLE}
+	${ZEPHYR_ZCBOR_MODULE_DIR}/zcbor/zcbor.py
+	code
 	--cddl ${CMAKE_CURRENT_BINARY_DIR}/device_shadow.cddl
 	--decode # Generate decoding functions
 	--encode # Generate encoding functions
 	--short-names # Attempt to make generated symbol names shorter (at the risk of collision)
 	-t shadow-object # Create a public API for encoding and decoding the "shadow-object" type from the cddl file
 	--output-cmake device_shadow.cmake # The generated cmake file will be placed here
+	--unordered-maps # Enable support for unordered maps
+	--defines
 )
 execute_process(COMMAND ${zcbor_command}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/app/src/cbor/cbor_helper.c
+++ b/app/src/cbor/cbor_helper.c
@@ -59,7 +59,8 @@ int decode_shadow_parameters_from_cbor(const uint8_t *cbor, size_t len,
 	}
 
 	if (shadow.command_present) {
-		*command_type = shadow.command.type;
+		// *command_type = shadow.command.type;
+		*command_type = 1; /* Only support command type 1 for now, which is "execute command" */
 		*command_id = shadow.command.id;
 
 		LOG_DBG("Command parameter present: type=%u, id=%u", *command_type, *command_id);
@@ -102,7 +103,7 @@ int encode_shadow_parameters_to_cbor(const struct config_params *config, uint32_
 	/* Build shadow object with command section */
 	if (command_type > 0) {
 		shadow.command_present = true;
-		shadow.command.type = command_type;
+		// shadow.command.type = command_type;
 		shadow.command.id = command_id;
 	}
 

--- a/app/src/cbor/device_shadow.cddl
+++ b/app/src/cbor/device_shadow.cddl
@@ -1,8 +1,7 @@
 ; Device Shadow Object Definition
 ; --------------------------------
 ; This unified structure defines both "desired" (cloud-to-device) and "reported" (device-to-cloud)
-; objects in the device shadow. All sections are optional, but if present, they must appear in
-; the specified order when decoding the CBOR buffer.
+; objects in the device shadow. All sections are optional.
 ;
 ; Sections:
 ; 1. "config": Device configuration parameters.
@@ -37,6 +36,6 @@ shadow-object = {
         ? "storage_threshold": uint .size 4 .ge 0 .le @CONFIG_APP_STORAGE_MAX_RECORDS_PER_TYPE@,
         * tstr => any
     },
-    ? "command": [type: uint .size 4 .ge 1 .le 1, id: uint .size 4 .ge 1 .le 4294967295],
+    ? "command": [type: uint .eq 1, id: uint .size 4 .ge 1 .le 4294967295],
     * tstr => any
 }

--- a/west.yml
+++ b/west.yml
@@ -9,6 +9,8 @@ manifest:
   remotes:
     - name: ncs
       url-base: https://github.com/nrfconnect
+    - name: nordicsemi
+      url-base: https://github.com/nordicsemi
 
   projects:
     - name: nrf
@@ -16,3 +18,8 @@ manifest:
       repo-path: sdk-nrf
       revision: v3.3.0-rc2
       import: true
+    - name: zcbor
+      remote: nordicsemi
+      repo-path: zcbor
+      revision: pull/425/head
+      path: modules/lib/zcbor


### PR DESCRIPTION
- Use unordered maps for device shadow decoding, allowing the fields to be in any order.
- Overrides the default zcbor source from the Zephyr fork to nordic upstream, which includes the necessary changes for unordered maps.