### PR TITLE
.github: workflows: ncsref-update: prune Docker resources before build

### DIFF
--- a/.github/workflows/ncsref-update.yaml
+++ b/.github/workflows/ncsref-update.yaml
@@ -9,7 +9,14 @@ permissions:
   contents: read
 
 jobs:
+  prune-runner:
+    runs-on: build_self_hosted
+    steps:
+      - name: Prune Docker images and containers on the runner host
+        run: sudo docker system prune --all --force
+
   build:
+    needs: prune-runner
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Add a `prune-runner` job that runs `docker system prune --all --force` on the self-hosted runner before the `build` job starts. This frees up disk space by removing unused images and containers, preventing build failures caused by low storage on the runner host.