### PR TITLE
.github: workflows: Upload symbol files to test fleet and ci accounts

### DIFF
--- a/.github/workflows/publish-symbol-files-to-memfault.yml
+++ b/.github/workflows/publish-symbol-files-to-memfault.yml
@@ -35,13 +35,24 @@ jobs:
 
       - run: node .github/workflows/fetch-release-assets.mjs ${{ inputs.version }}
 
-      - name: Publish Memfault debug symbols
+      - name: Publish Memfault debug symbols (nightly CI account)
         run: |
           source venv/bin/activate
           memfault \
               --org-token ${{ secrets.MEMFAULT_ORGANIZATION_TOKEN }} \
               --org ${{ vars.MEMFAULT_ORGANIZATION_SLUG }} \
               --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
+              upload-mcu-symbols \
+              --check-uploaded \
+              asset-tracker-template-${{ inputs.version }}-debug-thingy91x-nrf91.elf
+
+      - name: Publish Memfault debug symbols (test fleet account)
+        run: |
+          source venv/bin/activate
+          memfault \
+              --org-token ${{ secrets.MEMFAULT_FLEET_ORGANIZATION_TOKEN }} \
+              --org ${{ vars.MEMFAULT_FLEET_ORGANIZATION_SLUG }} \
+              --project ${{ vars.MEMFAULT_FLEET_PROJECT_SLUG }} \
               upload-mcu-symbols \
               --check-uploaded \
               asset-tracker-template-${{ inputs.version }}-debug-thingy91x-nrf91.elf

--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -119,7 +119,7 @@ jobs:
           pip install -r requirements.txt --break-system-packages
           nrfutil install trace
 
-      - name: Upload symbol file to Memfault
+      - name: Upload symbol file to Memfault (nightly CI account)
         if: ${{ matrix.device == 'thingy91x' && inputs.run_nightly_tests }}
         working-directory: asset-tracker-template/tests/on_target/artifacts
         run: |


### PR DESCRIPTION
Upload symbol files to both the test fleet and ci accounts.