### PR TITLE
.github: workflows: build: add concurrency group to cancel ongoing runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,11 @@ on:
 permissions:
   contents: read
 
+# Cancel any in-progress run for the same PR
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: build_self_hosted


### PR DESCRIPTION
Add a `concurrency` block to cancel any in-progress workflow run for the same PR when a new commit is pushed.