### PR TITLE
Implement session timeout and idle state transition for storage

### DIFF
--- a/app/src/modules/storage/storage.c
+++ b/app/src/modules/storage/storage.c
@@ -632,7 +632,6 @@ static int start_batch_session(struct storage_state *state_object,
 
 	/* Enforce non-zero session id */
 	if (request_msg->session_id == 0U) {
-		send_batch_error_response(request_msg->session_id);
 		return -EINVAL;
 	}
 
@@ -646,8 +645,6 @@ static int start_batch_session(struct storage_state *state_object,
 	}
 
 	if (total_items == 0) {
-		send_batch_empty_response(request_msg->session_id);
-
 		return -ENODATA;
 	}
 
@@ -662,9 +659,6 @@ static int start_batch_session(struct storage_state *state_object,
 	/* Try to populate the pipe */
 	err = populate_pipe(state_object);
 	if (err < 0) {
-		/* Error occurred during pipe population */
-		send_batch_error_response(request_msg->session_id);
-
 		LOG_ERR("Failed to populate pipe for session 0x%X: %d",
 			state_object->current_session.session_id, err);
 
@@ -877,11 +871,13 @@ static void state_buffer_pipe_active_entry(void *o)
 	if (err == -ENODATA) {
 		/* No data available, report it */
 		send_batch_empty_response(msg->session_id);
+		smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
 
 		return;
 	} else if (err) {
 		LOG_ERR("Failed to start pipe session: %d", err);
 		send_batch_error_response(msg->session_id);
+		smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
 
 		return;
 	}
@@ -917,7 +913,9 @@ static enum smf_state_result state_buffer_pipe_active_run(void *o)
 
 			return SMF_EVENT_HANDLED;
 
-		case STORAGE_BATCH_REQUEST:
+		case STORAGE_BATCH_REQUEST: {
+			int err;
+
 			LOG_DBG("Batch request received, session_id: 0x%X", msg->session_id);
 
 			if (state_object->current_session.session_id &&
@@ -932,7 +930,20 @@ static enum smf_state_result state_buffer_pipe_active_run(void *o)
 			/* We allow multiple requests in the same session.
 			 * The batch will be refreshed with new data.
 			 */
-			start_batch_session(state_object, msg);
+			err = start_batch_session(state_object, msg);
+			if (err == -ENODATA) {
+				send_batch_empty_response(msg->session_id);
+				smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
+
+				return SMF_EVENT_HANDLED;
+			} else if (err) {
+				LOG_ERR("Failed to refresh pipe session: %d", err);
+				send_batch_error_response(msg->session_id);
+				smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
+
+				return SMF_EVENT_HANDLED;
+			}
+
 			LOG_DBG("Session started: 0x%X", state_object->current_session.session_id);
 
 			/* Reset session timeout on activity */
@@ -940,6 +951,7 @@ static enum smf_state_result state_buffer_pipe_active_run(void *o)
 					  K_SECONDS(STORAGE_SESSION_TIMEOUT_SECONDS));
 
 			return SMF_EVENT_HANDLED;
+		}
 
 		default:
 			/* Don't care */

--- a/tests/module/storage/src/storage_module_test.c
+++ b/tests/module/storage/src/storage_module_test.c
@@ -409,6 +409,45 @@ void test_storage_batch_request_empty(void)
 	close_batch_and_assert(received_msg.session_id);
 }
 
+/* Regression test for the case where a STORAGE_BATCH_REQUEST is issued while the
+ * backend is empty. The module must roll back to STATE_BUFFER_IDLE on its own
+ * after replying with STORAGE_BATCH_EMPTY, so that a follow-up request with a
+ * different session id is served normally instead of being rejected with
+ * STORAGE_BATCH_BUSY.
+ */
+void test_storage_batch_empty_does_not_block_next_request(void)
+{
+	int err;
+	struct storage_msg first_request = {
+		.type = STORAGE_BATCH_REQUEST,
+		.session_id = 0xAAAA0001,
+	};
+	struct storage_msg second_request = {
+		.type = STORAGE_BATCH_REQUEST,
+		.session_id = 0xAAAA0002,
+	};
+
+	/* First request on an empty backend must produce BATCH_EMPTY for its session ID. */
+	err = zbus_chan_pub(&storage_chan, &first_request, K_SECONDS(1));
+	TEST_ASSERT_EQUAL(0, err);
+
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_EMPTY, received_msg.type);
+	TEST_ASSERT_EQUAL(first_request.session_id, received_msg.session_id);
+
+	err = zbus_chan_pub(&storage_chan, &second_request, K_SECONDS(1));
+	TEST_ASSERT_EQUAL(0, err);
+
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_NOT_EQUAL(STORAGE_BATCH_BUSY, received_msg.type);
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_EMPTY, received_msg.type);
+	TEST_ASSERT_EQUAL(second_request.session_id, received_msg.session_id);
+
+	close_batch_and_assert(received_msg.session_id);
+}
+
 void test_storage_batch_request_and_retrieve(void)
 {
 	int err;


### PR DESCRIPTION
* Transition to idle if storage was empty
* Add test case to check that batch session is not active when attempting to start one with empty storage