### PR TITLE
app: main: Don't always send on connect

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -265,6 +265,11 @@ struct main_state {
 	 */
 	bool cloud_synced_on_connect;
 
+	/* Flag to track if the storage threshold was reached while disconnected.
+	 * Used to decide whether to send data immediately on reconnection.
+	 */
+	bool threshold_reached;
+
 	/* Flags to track if each module is ready */
 	struct {
 		bool fota_ready;
@@ -321,7 +326,7 @@ static const struct smf_state states[] = {
 		connected_run,
 		NULL,
 		&states[STATE_RUNNING],
-		&states[STATE_CONNECTED_SENDING]
+		&states[STATE_CONNECTED_WAITING]
 	),
 	/* Connected operation states */
 	[STATE_CONNECTED_SAMPLING] = SMF_CREATE_STATE(
@@ -1105,7 +1110,13 @@ static enum smf_state_result disconnected_run(void *o)
 		const struct cloud_msg *msg = (const struct cloud_msg *)state_object->msg_buf;
 
 		if (msg->type == CLOUD_CONNECTED) {
-			smf_set_state(SMF_CTX(state_object), &states[STATE_CONNECTED]);
+			if (state_object->threshold_reached) {
+				state_object->threshold_reached = false;
+				smf_set_state(SMF_CTX(state_object),
+					      &states[STATE_CONNECTED_SENDING]);
+			} else {
+				smf_set_state(SMF_CTX(state_object), &states[STATE_CONNECTED]);
+			}
 
 			return SMF_EVENT_HANDLED;
 		}
@@ -1138,6 +1149,7 @@ static enum smf_state_result disconnected_run(void *o)
 		const struct storage_msg *msg = (const struct storage_msg *)state_object->msg_buf;
 
 		if (msg->type == STORAGE_THRESHOLD_REACHED) {
+			state_object->threshold_reached = true;
 			return SMF_EVENT_HANDLED;
 		}
 	}

--- a/tests/module/main/src/main.c
+++ b/tests/module/main/src/main.c
@@ -338,15 +338,6 @@ static void connect_to_cloud(void)
 {
 	send_cloud_connected();
 	expect_cloud_event(CLOUD_CONNECTED);
-
-	/* Expect events from connected_sending_entry -> cloud_send_now() */
-	expect_storage_event(STORAGE_BATCH_REQUEST);
-	expect_fota_event(FOTA_POLL_REQUEST);
-	expect_cloud_event(CLOUD_SHADOW_GET_DELTA);
-
-	/* Complete the send cycle to transition to STATE_CONNECTED_WAITING */
-	send_storage_batch_close();
-	expect_storage_event(STORAGE_BATCH_CLOSE);
 }
 
 void setUp(void)
@@ -392,11 +383,6 @@ void test_init_first_connection(void)
 	expect_cloud_event(CLOUD_SHADOW_UPDATE_REPORTED_DEVICE);
 	expect_fota_event(FOTA_POLL_REQUEST);
 	expect_cloud_event(CLOUD_SHADOW_GET_DESIRED);
-
-	/* STATE_CONNECTED_SENDING dispatches stored data on connection */
-	expect_storage_event(STORAGE_BATCH_REQUEST);
-	expect_fota_event(FOTA_POLL_REQUEST);
-	expect_cloud_event(CLOUD_SHADOW_GET_DELTA);
 }
 
 void test_short_button_press_connected(void)
@@ -461,6 +447,17 @@ void test_threshold_reached_disconnected(void)
 	send_storage_threshold_reached();
 	expect_storage_event(STORAGE_THRESHOLD_REACHED);
 	expect_no_events(500);
+
+	/* Connection after threshold reached should trigger immediate sending */
+	connect_to_cloud();
+	/* Expect events from connected_sending_entry -> cloud_send_now() */
+	expect_storage_event(STORAGE_BATCH_REQUEST);
+	expect_fota_event(FOTA_POLL_REQUEST);
+	expect_cloud_event(CLOUD_SHADOW_GET_DELTA);
+
+	/* Complete the send cycle to transition to STATE_CONNECTED_WAITING */
+	send_storage_batch_close();
+	expect_storage_event(STORAGE_BATCH_CLOSE);
 }
 
 void test_fota_downloading(void)
@@ -481,15 +478,6 @@ void test_fota_downloading(void)
 	/* Cleanup */
 	send_fota_msg(FOTA_DOWNLOAD_CANCELED);
 	expect_fota_event(FOTA_DOWNLOAD_CANCELED);
-
-	/* Resuming to STATE_CONNECTED enters STATE_CONNECTED_SENDING first */
-	expect_storage_event(STORAGE_BATCH_REQUEST);
-	expect_fota_event(FOTA_POLL_REQUEST);
-	expect_cloud_event(CLOUD_SHADOW_GET_DELTA);
-
-	/* Complete send cycle to transition to STATE_CONNECTED_WAITING */
-	send_storage_batch_close();
-	expect_storage_event(STORAGE_BATCH_CLOSE);
 
 	/* Then sampling resumes */
 	expect_location_event(LOCATION_SEARCH_TRIGGER);


### PR DESCRIPTION
Add logic to only send on connect if the threshold was exceeded while disconnected. This is to avoid sending data on connect if the buffer isn't full.