### PR TITLE
location: Handle missing current cell information in location requests

### DIFF
--- a/app/src/modules/location/location_helper.c
+++ b/app/src/modules/location/location_helper.c
@@ -116,6 +116,9 @@ int location_cloud_request_data_copy(struct location_cloud_request_data *dest,
 
 	LOG_DBG("Copying cloud request data, size of dest: %zu", sizeof(*dest));
 
+	/* Mark cell id as invalid by default, overwritten if valid data is available. */
+	dest->current_cell.id = LTE_LC_CELL_EUTRAN_ID_INVALID;
+
 #if defined(CONFIG_LOCATION_METHOD_CELLULAR)
 	if (src->cell_data) {
 		err = copy_cellular_data(dest, src->cell_data);


### PR DESCRIPTION
Set the current cell ID to LTE_LC_CELL_EUTRAN_ID_INVALID by default, overwriting it only if valid data is available. This allows the cloud location module to detect when no current cell information is provided in a location request.