### PR TITLE
app: storage + cloud: requeue on send failure

### DIFF
--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -595,7 +595,52 @@ static void handle_storage_batch_available(const struct storage_msg *msg)
 
 		err = send_storage_data_to_cloud(&item);
 		if (err) {
-			LOG_ERR("Failed to send storage data to cloud, error: %d", err);
+			int send_err = err;
+
+			/* Non-network errors (ENOTSUP, EINVAL, ENODATA) indicate malformed or
+			 * unsupported data that will never succeed. Drop the item to prevent
+			 * an infinite retry loop.
+			 */
+			if (send_err == -ENOTSUP || send_err == -EINVAL || send_err == -ENODATA) {
+				LOG_ERR("Permanent error sending storage data (type %d), "
+					"dropping item: %d", item.type, send_err);
+				continue;
+			}
+
+			/* Network/transport error: requeue the item so it can be retried in a
+			 * future batch session, then abort the loop since remaining sends will
+			 * also fail.
+			 */
+			LOG_ERR("Network error sending storage data (type %d), "
+				"requeueing item: %d", item.type, send_err);
+
+			struct storage_msg requeue_msg = {
+				.type = STORAGE_REQUEUE,
+				.data_type = item.type,
+			};
+
+			memcpy(requeue_msg.buffer, &item.data, sizeof(item.data));
+
+			err = zbus_chan_pub(&storage_chan, &requeue_msg, PUB_TIMEOUT);
+			if (err) {
+				LOG_ERR("Failed to requeue item, error: %d", err);
+			}
+
+			session_error = true;
+			continue;
+		}
+
+		/* Reset the storage session timeout so slow sends don't cause
+		 * premature session expiry
+		 */
+		struct storage_msg keepalive_msg = {
+			.type = STORAGE_BATCH_KEEPALIVE,
+			.session_id = session_id,
+		};
+
+		err = zbus_chan_pub(&storage_chan, &keepalive_msg, PUB_TIMEOUT);
+		if (err) {
+			LOG_ERR("Failed to send batch keepalive, error: %d", err);
 		}
 
 		items_processed++;

--- a/app/src/modules/storage/Kconfig.storage
+++ b/app/src/modules/storage/Kconfig.storage
@@ -88,7 +88,7 @@ config APP_STORAGE_BATCH_BUFFER_SIZE
 
 config APP_STORAGE_SESSION_TIMEOUT_SECONDS
 	int "Storage batch session timeout"
-	default 60
+	default 30
 	help
 	  Timeout for an active storage batch session. If no activity
 	  occurs on the session for this duration, it will be automatically

--- a/app/src/modules/storage/storage.c
+++ b/app/src/modules/storage/storage.c
@@ -462,6 +462,73 @@ static void drain_pipe(void)
 	}
 }
 
+/* Re-store an item that failed to be sent to cloud so it can be retried later */
+static void requeue_item(enum storage_data_type data_type, const uint8_t *buf)
+{
+	int err;
+	const struct storage_backend *backend = storage_backend_get();
+	bool found = false;
+
+	STRUCT_SECTION_FOREACH(storage_data, type) {
+		if (type->data_type == data_type) {
+			found = true;
+			err = backend->store(type, buf, type->data_size);
+			if (err) {
+				LOG_ERR("Failed to requeue item (type %d): %d", data_type, err);
+			} else {
+				LOG_DBG("Requeued item (type %d) for later send", data_type);
+			}
+			break;
+		}
+	}
+
+	if (!found) {
+		LOG_WRN("Requeue: unknown data type %d", data_type);
+	}
+}
+
+/* Requeue all items remaining in the pipe back to the storage backend. */
+static void requeue_pipe_data(void)
+{
+	int ret;
+	int requeued = 0;
+	struct storage_pipe_header header;
+	uint8_t data[STORAGE_MAX_DATA_SIZE];
+
+	while (true) {
+		ret = pipe_read_exact(&storage_pipe, (uint8_t *)&header,
+				      sizeof(header), K_NO_WAIT);
+		if (ret == -EAGAIN) {
+			/* Pipe empty - done */
+			break;
+		} else if (ret < 0) {
+			LOG_ERR("Pipe read error during requeue: %d, draining", ret);
+			drain_pipe();
+			return;
+		}
+
+		if (header.data_size > STORAGE_MAX_DATA_SIZE) {
+			LOG_ERR("Corrupt pipe header (size=%u), draining", header.data_size);
+			drain_pipe();
+			return;
+		}
+
+		ret = pipe_read_exact(&storage_pipe, data, header.data_size, K_NO_WAIT);
+		if (ret < 0) {
+			LOG_ERR("Failed to read pipe data for requeue: %d, draining", ret);
+			drain_pipe();
+			return;
+		}
+
+		requeue_item((enum storage_data_type)header.type, data);
+		requeued++;
+	}
+
+	if (requeued > 0) {
+		LOG_DBG("Requeued %d item(s) from pipe back to storage backend", requeued);
+	}
+}
+
 /* Send batch response message with session_id and optional data_len */
 static void send_batch_response(enum storage_msg_type response_type,
 			       uint32_t session_id,
@@ -816,6 +883,9 @@ static enum smf_state_result state_running_run(void *o)
 			handle_storage_stats();
 			break;
 #endif /* CONFIG_APP_STORAGE_SHELL_STATS */
+		case STORAGE_REQUEUE:
+			requeue_item(msg->data_type, msg->buffer);
+			break;
 		default:
 			break;
 		}
@@ -906,6 +976,19 @@ static enum smf_state_result state_buffer_pipe_active_run(void *o)
 
 			return SMF_EVENT_HANDLED;
 
+		case STORAGE_REQUEUE:
+			requeue_item(msg->data_type, msg->buffer);
+			return SMF_EVENT_HANDLED;
+
+		case STORAGE_BATCH_KEEPALIVE:
+			if (state_object->current_session.session_id == msg->session_id) {
+				k_work_reschedule(&state_object->session_timeout_work,
+						  K_SECONDS(STORAGE_SESSION_TIMEOUT_SECONDS));
+				LOG_DBG("Session 0x%X keepalive, timeout reset",
+					msg->session_id);
+			}
+			return SMF_EVENT_HANDLED;
+
 		case STORAGE_BATCH_REQUEST: {
 			int err;
 
@@ -987,8 +1070,10 @@ static void state_buffer_pipe_active_exit(void *o)
 	/* Cancel session timeout */
 	k_work_cancel_delayable(&state_object->session_timeout_work);
 
-	/* Drain any remaining data from pipe */
-	drain_pipe();
+	/* Requeue unconsumed pipe items back to storage backend so they
+	 * are not lost if the session closes with unsent data.
+	 */
+	requeue_pipe_data();
 
 	/* Clear session state */
 	memset(&state_object->current_session, 0, sizeof(state_object->current_session));

--- a/app/src/modules/storage/storage.h
+++ b/app/src/modules/storage/storage.h
@@ -52,6 +52,15 @@ enum storage_msg_type {
 	 */
 	STORAGE_STATS,
 
+	/* Re-store a previously retrieved item that failed to be sent to cloud.
+	 * Use this when sending an item fails and the item should be re-queued
+	 * for a future send attempt.
+	 * The message must contain:
+	 *   - `data_type`: identifies the type of data to re-store
+	 *   - `buffer`: the raw data in storage format (same layout as originally stored)
+	 */
+	STORAGE_REQUEUE,
+
 	/* Output messages */
 
 	/* Number of items in storage >= trigger limit.
@@ -82,6 +91,13 @@ enum storage_msg_type {
 
 	/* Batch is busy - cannot process request at this time. */
 	STORAGE_BATCH_BUSY,
+
+	/* Keepalive to reset the batch session timeout while items are being processed.
+	 * The consumer should send this after each successfully delivered item to prevent
+	 * the session from timing out during slow sends (e.g. congested CoAP links).
+	 * The message must contain the same session_id as the active batch session.
+	 */
+	STORAGE_BATCH_KEEPALIVE,
 };
 
 /**

--- a/tests/module/cloud/src/cloud_module_test.c
+++ b/tests/module/cloud/src/cloud_module_test.c
@@ -148,8 +148,12 @@ static K_SEM_DEFINE(cloud_connected, 0, 1);
 static K_SEM_DEFINE(data_sent, 0, 1);
 static K_SEM_DEFINE(cloud_module_response_recv_sem, 0, 1);
 static K_SEM_DEFINE(storage_batch_closed, 0, 1);
+static K_SEM_DEFINE(storage_requeue_sem, 0, 1);
+static K_SEM_DEFINE(storage_keepalive_sem, 0, 4);
 static struct cloud_msg last_shadow_response;
 static struct storage_msg last_storage_msg;
+static struct storage_msg last_requeue_msg;
+static struct storage_msg last_keepalive_msg;
 static struct nrf_cloud_gnss_data last_gnss_data;
 
 static nrf_provisioning_event_cb_t handler;
@@ -172,6 +176,8 @@ enum fake_batch_mode {
 	FAKE_BATCH_NONE = 0,
 	FAKE_BATCH_BATTERY,
 	FAKE_BATCH_ENV,
+	/* Returns two battery items, call 0 and call 1 both yield a battery item */
+	FAKE_BATCH_TWO_BATTERY,
 };
 
 static enum fake_batch_mode fake_mode;
@@ -185,9 +191,12 @@ static int storage_batch_read_custom(struct storage_data_item *out_item, k_timeo
 		return -EAGAIN;
 	}
 
-	if (fake_read_calls++ == 0) {
+	int call = fake_read_calls++;
+
+	if (call == 0) {
 		switch (fake_mode) {
 		case FAKE_BATCH_BATTERY:
+		case FAKE_BATCH_TWO_BATTERY:
 			out_item->type = STORAGE_TYPE_BATTERY;
 			out_item->data.BATTERY.percentage = 87.5;
 			out_item->data.BATTERY.timestamp = TEST_BATTERY_UPTIME_MS;
@@ -202,11 +211,36 @@ static int storage_batch_read_custom(struct storage_data_item *out_item, k_timeo
 		default:
 			return -EAGAIN;
 		}
+		return 0;
+	}
 
+	else if (call == 1 && (fake_mode == FAKE_BATCH_TWO_BATTERY)) {
+		out_item->type = STORAGE_TYPE_BATTERY;
+		out_item->data.BATTERY.percentage = 85.5;
+		out_item->data.BATTERY.timestamp = TEST_BATTERY_UPTIME_MS;
 		return 0;
 	}
 
 	return -EAGAIN;
+}
+
+/*
+ * Custom fake for nrf_cloud_coap_sensor_send that fails only on the first call
+ * (simulating a single bad item in a multi-item batch).
+ */
+static int nrf_cloud_coap_sensor_send_fail_first_custom_fake(
+	const char *app_id, double value, int64_t ts, bool confirmable)
+{
+	ARG_UNUSED(app_id);
+	ARG_UNUSED(value);
+	ARG_UNUSED(ts);
+	ARG_UNUSED(confirmable);
+
+	if (nrf_cloud_coap_sensor_send_fake.call_count == 1) {
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static int nrf_cloud_client_id_get_custom_fake(char *buf, size_t len)
@@ -279,6 +313,12 @@ static void cloud_chan_cb(const struct zbus_channel *chan)
 		if (storage_msg->type == STORAGE_BATCH_CLOSE) {
 			memcpy(&last_storage_msg, storage_msg, sizeof(struct storage_msg));
 			k_sem_give(&storage_batch_closed);
+		} else if (storage_msg->type == STORAGE_REQUEUE) {
+			memcpy(&last_requeue_msg, storage_msg, sizeof(struct storage_msg));
+			k_sem_give(&storage_requeue_sem);
+		} else if (storage_msg->type == STORAGE_BATCH_KEEPALIVE) {
+			memcpy(&last_keepalive_msg, storage_msg, sizeof(struct storage_msg));
+			k_sem_give(&storage_keepalive_sem);
 		}
 	}
 }
@@ -420,6 +460,10 @@ void setUp(void)
 	k_sem_reset(&data_sent);
 	k_sem_reset(&cloud_module_response_recv_sem);
 	k_sem_reset(&storage_batch_closed);
+	k_sem_reset(&storage_requeue_sem);
+	k_sem_reset(&storage_keepalive_sem);
+	memset(&last_requeue_msg, 0, sizeof(last_requeue_msg));
+	memset(&last_keepalive_msg, 0, sizeof(last_keepalive_msg));
 
 	/* Set default return values */
 	nrf_cloud_coap_location_send_fake.return_val = 0;
@@ -1619,6 +1663,24 @@ static void wait_for_storage_batch_close(k_timeout_t timeout)
 	TEST_ASSERT_EQUAL(0, err);
 }
 
+/* Helper to wait for a STORAGE_REQUEUE message from the cloud module */
+static void wait_for_requeue(k_timeout_t timeout)
+{
+	int err;
+
+	err = k_sem_take(&storage_requeue_sem, timeout);
+	TEST_ASSERT_EQUAL(0, err);
+}
+
+/* Helper to wait for a STORAGE_BATCH_KEEPALIVE message from the cloud module */
+static void wait_for_keepalive(k_timeout_t timeout)
+{
+	int err;
+
+	err = k_sem_take(&storage_keepalive_sem, timeout);
+	TEST_ASSERT_EQUAL(0, err);
+}
+
 void test_storage_batch_available_when_paused_should_close_session(void)
 {
 	struct storage_msg batch_available = {
@@ -1727,6 +1789,128 @@ void test_agnss_request_cached_while_disconnected_and_sent_on_connect(void)
 	/* Verify the cached A-GNSS request was sent after connecting */
 	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_agnss_data_get_fake.call_count);
 	TEST_ASSERT_EQUAL(1, location_agnss_data_process_fake.call_count);
+}
+
+/* Verify STORAGE_BATCH_KEEPALIVE is published to storage_chan after each successful send */
+void test_batch_keepalive_sent_after_successful_send(void)
+{
+	struct storage_msg batch_available = {
+		.type = STORAGE_BATCH_AVAILABLE,
+		.data_len = 1,
+		.session_id = 0x12AB34CD,
+		.more_data = false,
+	};
+
+	connect_cloud();
+
+	/* Prepare fake to return one battery item, then -EAGAIN */
+	fake_mode = FAKE_BATCH_BATTERY;
+	fake_read_calls = 0;
+	storage_batch_read_fake.custom_fake = storage_batch_read_custom;
+
+	publish_and_assert(&storage_chan, &batch_available);
+
+	/* Keepalive is published after the successful send */
+	wait_for_keepalive(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_KEEPALIVE, last_keepalive_msg.type);
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_keepalive_msg.session_id);
+
+	/* Verify the send was made */
+	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_sensor_send_fake.call_count);
+
+	/* Verify session is closed after processing */
+	wait_for_storage_batch_close(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_storage_msg.session_id);
+}
+
+/* Verify that a permanent/non-network error (-EINVAL) on one batch item drops only
+ * that item, and that the batch loop continues to process remaining items without
+ * requeuing the failed item.
+ */
+void test_batch_permanent_error_drops_item_without_requeue(void)
+{
+	struct storage_msg batch_available = {
+		.type = STORAGE_BATCH_AVAILABLE,
+		.data_len = 2,
+		.session_id = 0xABCD1234,
+		.more_data = false,
+	};
+
+	connect_cloud();
+
+	/* Setup fake to return two battery items, then -EAGAIN, and configure send to fail with
+	 * -EINVAL for the first item and succeed for the second item
+	 */
+	fake_mode = FAKE_BATCH_TWO_BATTERY;
+	fake_read_calls = 0;
+	storage_batch_read_fake.custom_fake = storage_batch_read_custom;
+	nrf_cloud_coap_sensor_send_fake.custom_fake = nrf_cloud_coap_sensor_send_fail_first_custom_fake;
+
+	publish_and_assert(&storage_chan, &batch_available);
+
+	/* Keepalive must be sent for the successfully delivered second battery item */
+	wait_for_keepalive(K_SECONDS(WAIT_TIMEOUT));
+
+	/* Session must be closed after processing both items */
+	wait_for_storage_batch_close(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_storage_msg.session_id);
+
+	/* Exactly one keepalive was sent, confirming only one item succeeded */
+	TEST_ASSERT_EQUAL(0, k_sem_count_get(&storage_keepalive_sem));
+
+	/* The failed first battery item must NOT have been requeued */
+	TEST_ASSERT_EQUAL(0, k_sem_count_get(&storage_requeue_sem));
+
+	/* Shadow network info was updated */
+	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_shadow_network_info_update_fake.call_count);
+
+	/* 1 failed send + 1 successful send = 2 total */
+	TEST_ASSERT_EQUAL(2, nrf_cloud_coap_sensor_send_fake.call_count);
+}
+
+/* Verify that a network error (-EIO) causes the batch loop to abort, and requeue is published
+ * for the failed item.
+ */
+void test_batch_network_error_aborts_loop_and_requeues(void)
+{
+	struct storage_msg batch_available = {
+		.type = STORAGE_BATCH_AVAILABLE,
+		.data_len = 2,
+		.session_id = 0xFEEDFACE,
+		.more_data = false,
+	};
+
+	connect_cloud();
+
+
+	/* Setup fake to return two battery items, then -EAGAIN */
+	fake_mode = FAKE_BATCH_TWO_BATTERY;
+	fake_read_calls = 0;
+	storage_batch_read_fake.custom_fake = storage_batch_read_custom;
+	/* Network send fails with -EIO */
+	nrf_cloud_coap_sensor_send_fake.return_val = -EIO;
+
+	publish_and_assert(&storage_chan, &batch_available);
+
+	/* Requeue should be published for the failed item */
+	wait_for_requeue(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(STORAGE_REQUEUE, last_requeue_msg.type);
+	TEST_ASSERT_EQUAL(STORAGE_TYPE_BATTERY, last_requeue_msg.data_type);
+
+	/* Session should be closed  */
+	wait_for_storage_batch_close(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_storage_msg.session_id);
+
+	/* No items were successfully delivered, so shadow network info should not be updated */
+	TEST_ASSERT_EQUAL(0, nrf_cloud_coap_shadow_network_info_update_fake.call_count);
+
+	/* Loop should have aborted after the failure, only one send should have been attempted */
+	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_sensor_send_fake.call_count);
+	/* Verify it was the first item (87.5%) — memcmp avoids Unity double support requirement */
+	double expected_pct = 87.5;
+	TEST_ASSERT_EQUAL_MEMORY(&expected_pct,
+				 &nrf_cloud_coap_sensor_send_fake.arg1_history[0],
+				 sizeof(double));
 }
 
 /* This is required to be added to each test. That is because unity's

--- a/tests/module/storage/littlefs_backend/testcase.yaml
+++ b/tests/module/storage/littlefs_backend/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  storage.module.littlefs:
+  asset_tracker_template.fw.storage.littlefs:
     tags: storage
     platform_allow:
       - native_sim

--- a/tests/module/storage/ram_backend/testcase.yaml
+++ b/tests/module/storage/ram_backend/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  storage.module.ram:
+  asset_tracker_template.fw.storage.ram:
     tags: storage
     platform_allow:
       - native_sim

--- a/tests/module/storage/src/storage_module_test.c
+++ b/tests/module/storage/src/storage_module_test.c
@@ -1087,6 +1087,172 @@ void test_storage_threshold(void)
 
 }
 
+/* Verify that STORAGE_REQUEUE re-inserts a previously read item so it appears in the
+ * next batch session.
+ */
+void test_storage_requeue_stores_item_for_next_batch(void)
+{
+	int err;
+	struct environmental_msg env_msg = {
+		.type = ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE,
+	};
+	struct storage_msg requeue_msg;
+	uint32_t session_id;
+	size_t items_read;
+
+	/* Store one environmental sample */
+	populate_env_message(0, &env_msg);
+	publish_and_assert(&environmental_chan, &env_msg);
+
+	/* Open a batch session and wait for data to be ready */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	TEST_ASSERT_GREATER_THAN(0, received_msg.data_len);
+	session_id = received_msg.session_id;
+
+	/* Read the item from the batch pipe */
+	items_read = read_batch_data(1);
+	TEST_ASSERT_EQUAL(1, items_read);
+	TEST_ASSERT_EQUAL(1, received_env_samples_count);
+
+	/* Requeue the item while the batch session is still active. */
+	memset(&requeue_msg, 0, sizeof(requeue_msg));
+	requeue_msg.type = STORAGE_REQUEUE;
+	requeue_msg.data_type = STORAGE_TYPE_ENVIRONMENTAL;
+	memcpy(requeue_msg.buffer, &received_env_samples[0], sizeof(struct environmental_msg));
+
+	err = zbus_chan_pub(&storage_chan, &requeue_msg, K_SECONDS(1));
+	TEST_ASSERT_EQUAL(0, err);
+
+	/* Close the batch session (pipe is empty — no items to requeue from pipe) */
+	close_batch_and_assert(session_id);
+	k_sleep(K_MSEC(500));
+
+	/* Reset counters before the next batch read */
+	received_env_samples_count = 0;
+	memset(&received_env_samples, 0, sizeof(received_env_samples));
+
+	/* The explicitly requeued item must appear in the next batch */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	TEST_ASSERT_GREATER_THAN(0, received_msg.data_len);
+
+	items_read = read_batch_data(received_msg.data_len);
+	TEST_ASSERT_EQUAL(1, items_read);
+	TEST_ASSERT_EQUAL(1, received_env_samples_count);
+	TEST_ASSERT_EQUAL_DOUBLE(env_samples[0].temperature, received_env_samples[0].temperature);
+	TEST_ASSERT_EQUAL_DOUBLE(env_samples[0].humidity, received_env_samples[0].humidity);
+	TEST_ASSERT_EQUAL_DOUBLE(env_samples[0].pressure, received_env_samples[0].pressure);
+
+	close_batch_and_assert(received_msg.session_id);
+}
+
+/* Verify that STORAGE_BATCH_KEEPALIVE is handled without corrupting state: the session
+ * must remain active (subsequent batch requests must return STORAGE_BATCH_BUSY).
+ */
+void test_storage_keepalive_keeps_session_alive(void)
+{
+	int err;
+	struct environmental_msg env_msg = {
+		.type = ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE,
+	};
+	struct storage_msg keepalive_msg;
+	struct storage_msg second_request = {
+		.type = STORAGE_BATCH_REQUEST,
+		.session_id = 0x22222222,
+	};
+	uint32_t session_id;
+
+	/* Store a sample so the batch session opens successfully */
+	populate_env_message(0, &env_msg);
+	publish_and_assert(&environmental_chan, &env_msg);
+
+	/* Open a batch session */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	session_id = received_msg.session_id;
+
+	/* Send a keepalive for the active session */
+	memset(&keepalive_msg, 0, sizeof(keepalive_msg));
+	keepalive_msg.type = STORAGE_BATCH_KEEPALIVE;
+	keepalive_msg.session_id = session_id;
+
+	err = zbus_chan_pub(&storage_chan, &keepalive_msg, K_SECONDS(1));
+	TEST_ASSERT_EQUAL(0, err);
+	k_sleep(K_MSEC(200));
+
+	/* A new request while the session is active must be rejected with STORAGE_BATCH_BUSY */
+	err = zbus_chan_pub(&storage_chan, &second_request, K_SECONDS(1));
+	TEST_ASSERT_EQUAL(0, err);
+	k_sleep(K_MSEC(200));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_BUSY, received_msg.type);
+
+	/* Close the original session cleanly */
+	close_batch_and_assert(session_id);
+}
+
+/* Verify that items remaining in the pipe when a batch session closes are re-stored
+ * in the backend by requeue_pipe_data() and become available in the next batch session.
+ */
+void test_storage_pipe_data_requeued_on_session_close(void)
+{
+	struct environmental_msg env_msg = {
+		.type = ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE,
+	};
+	uint32_t session_id;
+	size_t items_read;
+	const uint8_t num_samples = 3;
+
+	/* Store multiple environmental samples */
+	for (size_t i = 0; i < num_samples; i++) {
+		populate_env_message(i, &env_msg);
+		publish_and_assert(&environmental_chan, &env_msg);
+	}
+
+	/* Open a batch session and wait for all samples to be loaded into the pipe */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	/* Verify enough items are present to leave at least one in the pipe after partial read */
+	TEST_ASSERT_GREATER_THAN(1, received_msg.data_len);
+	session_id = received_msg.session_id;
+
+	/* Intentionally read only one item, leaving the rest in the pipe */
+	items_read = read_batch_data(1);
+	TEST_ASSERT_EQUAL(1, items_read);
+
+	/* Close the session — state_buffer_pipe_active_exit calls requeue_pipe_data()
+	 * which must store the remaining pipe items back to the storage backend.
+	 */
+	close_batch_and_assert(session_id);
+	k_sleep(K_MSEC(500));
+
+	/* Reset counters before the next batch read */
+	received_env_samples_count = 0;
+	memset(&received_env_samples, 0, sizeof(received_env_samples));
+
+	/* The requeued pipe items must appear in the next batch */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	TEST_ASSERT_GREATER_THAN(0, received_msg.data_len);
+
+	/* At least the (num_samples - 1) items left in the pipe must be available */
+	items_read = read_batch_data(received_msg.data_len);
+	TEST_ASSERT_GREATER_THAN(1, items_read);
+
+	close_batch_and_assert(received_msg.session_id);
+}
+
 extern int unity_main(void);
 
 int main(void)


### PR DESCRIPTION
When sending data to the cloud, if the send fails, we want to requeue the data back to storage so it can be retried later instead of being lost. This is done by draining any remaining items from the pipe and requeuing them back to storage when a session ends.