### PR TITLE
memfault: remove redundant chunk upload Kconfigs

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -127,6 +127,7 @@ CONFIG_FCB=y
 
 # Downloader - used by FOTAS
 CONFIG_DOWNLOADER=y
+CONFIG_DOWNLOADER_MAX_FILENAME_SIZE=400
 CONFIG_DOWNLOADER_STACK_SIZE=2000
 
 # Flash - Used by FOTA
@@ -157,20 +158,10 @@ CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP=y
 CONFIG_PM_PARTITION_SIZE_MEMFAULT_STORAGE=0x8000
 CONFIG_MEMFAULT_COREDUMP_STACK_SIZE_TO_COLLECT=512
 CONFIG_MEMFAULT_NCS_POST_COREDUMP_ON_NETWORK_CONNECTED=y
-CONFIG_MEMFAULT_PERIODIC_UPLOAD_USE_DEDICATED_WORKQUEUE=y
 
 # Upload Memfault data via nRF Cloud CoAP transport.
 CONFIG_MEMFAULT_USE_NRF_CLOUD_COAP=y
 CONFIG_MEMFAULT_HTTP_ENABLE=n
-
-# Increase max post size to maximum allowable to improve upload efficiency.
-# This value is calculated from:
-# (COAP_CLIENT_MESSAGE_SIZE + COAP_CLIENT_MESSAGE_HEADER_SIZE - 100B options overhead).
-CONFIG_MEMFAULT_COAP_MAX_POST_SIZE=972
-
-# Set max number of messages to send in one batch to max allowable to support
-# uploading flash-backed coredumps and modem traces in one upload attempt.
-CONFIG_MEMFAULT_COAP_MAX_MESSAGES_TO_SEND=10000
 
 # Enable a minimal set of Memfault metrics.
 CONFIG_MEMFAULT_NCS_LTE_METRICS=y

--- a/west.yml
+++ b/west.yml
@@ -9,6 +9,8 @@ manifest:
   remotes:
     - name: ncs
       url-base: https://github.com/nrfconnect
+    - name: memfault
+      url-base: https://github.com/memfault
 
   projects:
     - name: nrf
@@ -16,3 +18,7 @@ manifest:
       repo-path: sdk-nrf
       revision: v3.3.0
       import: true
+    - name: memfault-firmware-sdk
+      path: modules/lib/memfault-firmware-sdk
+      revision: 1.38.0
+      remote: memfault


### PR DESCRIPTION
The default settings for the Memfault CoAP chunk upload were improved in Memfault SDK v1.38.0. This commit removes now redudant Kconfig options. Namely:

- CONFIG_MEMFAULT_PERIODIC_UPLOAD_USE_DEDICATED_WORKQUEUE is default y on nRF91x platforms
- CONFIG_MEMFAULT_COAP_MAX_POST_SIZE has been removed; the chunk size is now derived automatically from CONFIG_COAP_CLIENT_BLOCK_SIZE and CONFIG_COAP_CLIENT_MESSAGE_HEADER_SIZE, ensuring each Memfault chunk maps 1:1 to one CoAP block.
- The message limit is now workqueue-aware: when using a dedicated workqueue (`CONFIG_MEMFAULT_PERIODIC_UPLOAD_USE_DEDICATED_WORKQUEUE`) such as in this application, uploads are unbounded so all pending data is drained in one pass

Additionally, in SDK v1.38.0, FOTA support is default-enabled, and the Memfault SDK nRF91 FOTA support requires
bumping the filename size in the download library. Since FOTA support is imminent, and this change would be
required shortly anyways, I chose to update that value instead of disabling FOTA.