### PR TITLE
app: storage + cloud: Keep data in storage until cloud confirms sent

### DIFF
--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -489,9 +489,7 @@ static int send_storage_data_to_cloud(const struct storage_data_item *item)
 	if (item->type == STORAGE_TYPE_LOCATION) {
 		const struct location_msg *loc = &item->data.LOCATION;
 
-		cloud_location_handle_message(loc);
-
-		return 0;
+		return cloud_location_handle_message(loc);
 	}
 #endif /* CONFIG_APP_LOCATION && CONFIG_LOCATION_METHOD_GNSS */
 
@@ -505,26 +503,6 @@ static int send_storage_data_to_cloud(const struct storage_data_item *item)
 	return -ENOTSUP;
 }
 
-static int request_storage_batch_data(uint32_t session_id)
-{
-	int err;
-	struct storage_msg msg = {
-		.type = STORAGE_BATCH_REQUEST,
-		.session_id = session_id,
-	};
-
-	LOG_DBG("Requesting storage batch data, session_id: 0x%X", msg.session_id);
-
-	err = zbus_chan_pub(&storage_chan, &msg, PUB_TIMEOUT);
-	if (err) {
-		LOG_ERR("Failed to request storage batch data, error: %d", err);
-
-		return err;
-	}
-
-	return 0;
-}
-
 static void handle_storage_batch_available(const struct storage_msg *msg)
 {
 	int err;
@@ -532,13 +510,18 @@ static void handle_storage_batch_available(const struct storage_msg *msg)
 	uint32_t items_processed = 0;
 	uint32_t items_available = msg->data_len;
 	uint32_t session_id = msg->session_id;
-	struct storage_msg close_msg = {
-		.type = STORAGE_BATCH_CLOSE,
+	struct storage_msg out_msg = {
 		.session_id = session_id,
 	};
 	bool session_error = false;
 
 	LOG_INF("Processing storage batch: %u items available", items_available);
+
+	/* Suppress delivery of storage_chan messages back to cloud_subscriber while we
+	 * are blocking in this loop.
+	 */
+	err = zbus_obs_set_chan_notification_mask(&cloud_subscriber, &storage_chan, true);
+	__ASSERT(err == 0, "cloud_subscriber not registered on storage_chan: %d", err);
 
 	/* Drain the batch buffer: read until timeout, abort on hard error */
 	while (!session_error) {
@@ -549,7 +532,6 @@ static void handle_storage_batch_available(const struct storage_msg *msg)
 			break;
 		} else if (err) {
 			LOG_ERR("storage_batch_read failed, error: %d", err);
-
 			session_error = true;
 
 			continue;
@@ -557,25 +539,33 @@ static void handle_storage_batch_available(const struct storage_msg *msg)
 
 		err = send_storage_data_to_cloud(&item);
 		if (err) {
-			LOG_ERR("Failed to send storage data to cloud, error: %d", err);
+			if (err == -ENOTSUP || err == -EINVAL) {
+				LOG_ERR("Data error sending data (type %d): %d", item.type, err);
+			} else {
+				LOG_WRN("Network error sending data (type %d): %d", item.type, err);
+				session_error = true;
+
+				continue;
+			}
+		} else {
+			items_processed++;
 		}
 
-		items_processed++;
+		/* Consume the item: confirms a successful send or skips a malformed item */
+		out_msg.type = STORAGE_BATCH_CONSUME;
+		out_msg.data_type = item.type;
+		err = zbus_chan_pub(&storage_chan, &out_msg, PUB_TIMEOUT);
+		if (err) {
+			LOG_ERR("Failed to consume storage item, error: %d", err);
+			SEND_FATAL_ERROR();
+		}
 	}
 
 	LOG_DBG("Processed %u/%u storage items", items_processed, items_available);
 
-	if (!session_error && msg->more_data) {
-		LOG_DBG("More data available in batch, requesting next batch");
-
-		err = request_storage_batch_data(session_id);
-		if (err) {
-			LOG_ERR("Failed to request next storage batch data, error: %d", err);
-			SEND_FATAL_ERROR();
-		}
-
-		return;
-	}
+	/* Re-enable storage_chan notifications to cloud_subscriber */
+	err = zbus_obs_set_chan_notification_mask(&cloud_subscriber, &storage_chan, false);
+	__ASSERT(err == 0, "cloud_subscriber not registered on storage_chan: %d", err);
 
 	if (items_processed > 0) {
 		err = nrf_cloud_coap_shadow_network_info_update();
@@ -587,7 +577,8 @@ static void handle_storage_batch_available(const struct storage_msg *msg)
 	}
 
 	/* Close the batch session */
-	err = zbus_chan_pub(&storage_chan, &close_msg, PUB_TIMEOUT);
+	out_msg.type = STORAGE_BATCH_CLOSE;
+	err = zbus_chan_pub(&storage_chan, &out_msg, PUB_TIMEOUT);
 	if (err) {
 		LOG_ERR("Failed to close storage batch session, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -1182,7 +1173,7 @@ static enum smf_state_result state_connected_ready_run(void *obj)
 		if (msg->type == LOCATION_AGNSS_REQUEST) {
 			LOG_DBG("A-GNSS data request received");
 
-			cloud_location_handle_message(msg);
+			(void)cloud_location_handle_message(msg);
 		}
 
 		return SMF_EVENT_HANDLED;

--- a/app/src/modules/cloud/cloud_location.c
+++ b/app/src/modules/cloud/cloud_location.c
@@ -254,8 +254,11 @@ static void handle_agnss_request(const struct nrf_modem_gnss_agnss_data_frame *r
 #endif /* CONFIG_NRF_CLOUD_AGNSS */
 
 #if defined(CONFIG_LOCATION_METHOD_GNSS)
-/* Handle GNSS location data from the location module */
-static void handle_gnss_location_data(const struct location_msg *location_msg)
+/* Handle GNSS location data from the location module.
+ *
+ * Returns 0 on successful send, or a negative errno on failure.
+ */
+static int handle_gnss_location_data(const struct location_msg *location_msg)
 {
 	int err;
 	int64_t timestamp_ms = NRF_CLOUD_NO_TIMESTAMP;
@@ -307,10 +310,11 @@ static void handle_gnss_location_data(const struct location_msg *location_msg)
 	if (err) {
 		LOG_ERR("nrf_cloud_coap_location_send, error: %d", err);
 		send_request_failed();
-		return;
+		return err;
 	}
 
 	LOG_INF("GNSS location data sent to nRF Cloud successfully");
+	return 0;
 }
 #endif /* CONFIG_LOCATION_METHOD_GNSS */
 
@@ -343,29 +347,28 @@ void cloud_location_agnss_process_cached(void)
 }
 #endif /* CONFIG_NRF_CLOUD_AGNSS */
 
-void cloud_location_handle_message(const struct location_msg *msg)
+int cloud_location_handle_message(const struct location_msg *msg)
 {
 	switch (msg->type) {
 	case LOCATION_CLOUD_REQUEST:
 		LOG_DBG("Cloud location request received");
 		handle_cloud_location_request(&msg->cloud_request);
-		break;
+		return 0;
 
 #if defined(CONFIG_NRF_CLOUD_AGNSS)
 	case LOCATION_AGNSS_REQUEST:
 		LOG_DBG("A-GNSS data request received");
 		handle_agnss_request(&msg->agnss_request);
-		break;
+		return 0;
 #endif /* CONFIG_NRF_CLOUD_AGNSS */
 
 #if defined(CONFIG_LOCATION_METHOD_GNSS)
 	case LOCATION_GNSS_DATA:
 		LOG_DBG("GNSS location data received");
-		handle_gnss_location_data(msg);
-		break;
+		return handle_gnss_location_data(msg);
 #endif /* CONFIG_LOCATION_METHOD_GNSS */
 
 	default:
-		break;
+		return 0;
 	}
 }

--- a/app/src/modules/cloud/cloud_location.h
+++ b/app/src/modules/cloud/cloud_location.h
@@ -19,8 +19,10 @@ extern "C" {
  * Processes location requests, A-GNSS requests, and GNSS location data.
  *
  * @param msg Pointer to location message
+ *
+ * @retval 0 on success or a negative errno on failure.
  */
-void cloud_location_handle_message(const struct location_msg *msg);
+int cloud_location_handle_message(const struct location_msg *msg);
 
 #if defined(CONFIG_NRF_CLOUD_AGNSS)
 /**

--- a/app/src/modules/storage/Kconfig.storage
+++ b/app/src/modules/storage/Kconfig.storage
@@ -76,19 +76,15 @@ config APP_STORAGE_MAX_RECORDS_PER_TYPE
 
 config APP_STORAGE_BATCH_BUFFER_SIZE
 	int "Storage batch buffer size in bytes"
-	default 1024
+	default 512
 	help
-	  Size of the internal buffer for batch data access.
-	  This buffer is used to transfer data from the storage backend
-	  to consuming modules via the batch interface.
-
-	  Larger buffers can improve throughput but use more RAM.
-	  Must be large enough to hold at least one complete data item
-	  plus its header.
+	  Size of the internal pipe used to stream batch data from the
+	  storage backend to the consumer. Must be large enough to hold
+	  one storage data item plus its pipe header.
 
 config APP_STORAGE_SESSION_TIMEOUT_SECONDS
 	int "Storage batch session timeout"
-	default 60
+	default 30
 	help
 	  Timeout for an active storage batch session. If no activity
 	  occurs on the session for this duration, it will be automatically

--- a/app/src/modules/storage/storage.c
+++ b/app/src/modules/storage/storage.c
@@ -149,12 +149,16 @@ struct storage_pipe_header {
 	uint16_t data_size;
 };
 
+/* Ensure the batch pipe is large enough to hold one full item plus its header. */
+BUILD_ASSERT(CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE >=
+	     sizeof(struct storage_pipe_header) + STORAGE_MAX_DATA_SIZE,
+	     "CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE is too small to hold the largest "
+	     "storage_data_item plus its pipe header");
+
 /* Pipe session tracking */
 struct pipe_session {
 	uint32_t session_id;
 	size_t total_items;
-	size_t items_sent;
-	bool more_data;
 };
 
 /* Storage module state object */
@@ -440,8 +444,7 @@ static void drain_pipe(void)
 /* Send batch response message with session_id and optional data_len */
 static void send_batch_response(enum storage_msg_type response_type,
 			       uint32_t session_id,
-			       size_t data_len,
-			       bool more_data)
+			       size_t data_len)
 {
 	int err;
 	struct storage_msg response_msg = { 0 };
@@ -449,7 +452,6 @@ static void send_batch_response(enum storage_msg_type response_type,
 	response_msg.type = response_type;
 	response_msg.session_id = session_id;
 	response_msg.data_len = (uint16_t)MIN(data_len, (size_t)UINT16_MAX);
-	response_msg.more_data = more_data;
 
 	err = zbus_chan_pub(&storage_chan, &response_msg, PUB_TIMEOUT);
 	if (err) {
@@ -461,129 +463,128 @@ static void send_batch_response(enum storage_msg_type response_type,
 /* Convenience wrappers for batch responses */
 static void send_batch_busy_response(uint32_t session_id)
 {
-	send_batch_response(STORAGE_BATCH_BUSY, session_id, 0, false);
+	send_batch_response(STORAGE_BATCH_BUSY, session_id, 0);
 }
 
 static void send_batch_empty_response(uint32_t session_id)
 {
-	send_batch_response(STORAGE_BATCH_EMPTY, session_id, 0, false);
+	send_batch_response(STORAGE_BATCH_EMPTY, session_id, 0);
 }
 
 static void send_batch_error_response(uint32_t session_id)
 {
-	send_batch_response(STORAGE_BATCH_ERROR, session_id, 0, false);
+	send_batch_response(STORAGE_BATCH_ERROR, session_id, 0);
 }
 
-static void send_batch_available_response(uint32_t session_id, size_t item_count,
-					  bool more_available)
+static void send_batch_available_response(uint32_t session_id, size_t item_count)
 {
-	send_batch_response(STORAGE_BATCH_AVAILABLE, session_id, item_count, more_available);
+	send_batch_response(STORAGE_BATCH_AVAILABLE, session_id, item_count);
 }
 
-/* Populate the pipe with all stored data
+/* Populate the pipe with the next pending item.
  *
- * @return 0 on success (all data written or pipe full)
- * @return -EIO on data retrieval or size validation error
+ * Peeks the head item of the first non-empty type and writes it to the pipe.
+ * The item is NOT removed from the backend; that only happens on STORAGE_BATCH_CONSUME.
+ *
+ * @return 0 on success (one item written to pipe)
+ * @return -ENODATA if no items are available across all types
+ * @return -EIO on peek or pipe write error
  */
 static int populate_pipe(struct storage_state *state_object)
 {
 	const struct storage_backend *backend = storage_backend_get();
-	size_t total_bytes_sent = 0;
 
-	state_object->current_session.more_data = false;
-
-	/* Populate pipe with all stored data */
 	STRUCT_SECTION_FOREACH(storage_data, type) {
-		int count = backend->count(type);
+		int ret;
+		uint8_t item_buffer[sizeof(struct storage_pipe_header) + STORAGE_MAX_DATA_SIZE];
+		struct storage_pipe_header *header = (struct storage_pipe_header *)item_buffer;
+		uint8_t *data = item_buffer + sizeof(struct storage_pipe_header);
+		size_t total_size;
 
-		while (count > 0) {
-			int ret;
-			size_t total_size;
-			uint8_t item_buffer[sizeof(struct storage_pipe_header) +
-					    STORAGE_MAX_DATA_SIZE];
-			struct storage_pipe_header *header =
-				(struct storage_pipe_header *)item_buffer;
-			uint8_t *data = item_buffer + sizeof(struct storage_pipe_header);
+		/* Peek the head item */
+		ret = backend->peek(type, data, STORAGE_MAX_DATA_SIZE);
+		if (ret == -EAGAIN) {
+			/* No items of this type, try next */
+			continue;
+		} else if (ret < 0) {
+			LOG_ERR("Failed to peek %s data: %d", type->name, ret);
+			return -EIO;
+		}
 
-			/* Peek at size without copying data (data = NULL) */
-			ret = backend->peek(type, NULL, 0);
-			if (ret == -EAGAIN) {
-				/* No more data of this type */
-				break;
-			} else if (ret < 0) {
-				LOG_ERR("Failed to peek %s data size: %d", type->name, ret);
+		if (ret > UINT16_MAX) {
+			LOG_ERR("Peek returned oversized item for %s: %d", type->name, ret);
+			return -EIO;
+		}
 
-				return -EIO;
-			}
+		header->type = (uint8_t)type->data_type;
+		header->data_size = (uint16_t)ret;
+		total_size = sizeof(struct storage_pipe_header) + (size_t)ret;
 
-			/* Prepare header with actual size */
-			header->type = (uint8_t)type->data_type;
+		ret = pipe_write_all(&storage_pipe, item_buffer, total_size, PUB_TIMEOUT);
+		if (ret < 0) {
+			LOG_ERR("Unexpected pipe write failure: %d", ret);
+			return -EIO;
+		}
 
-			if ((ret < 0) || (ret > (int)STORAGE_MAX_DATA_SIZE) ||
-			    (ret > UINT16_MAX)) {
-				LOG_ERR("Invalid data size for header: %d", ret);
+		LOG_DBG("Pipe populated for session 0x%X: with %s item (%zu bytes)",
+			state_object->current_session.session_id,
+			type->name, total_size);
 
-				return -EIO;
-			}
+		return 0;
+	}
 
-			header->data_size = (uint16_t)ret;
+	return -ENODATA;
+}
 
-			/* Calculate exact total size needed using actual data size */
-			total_size = sizeof(struct storage_pipe_header) + ret;
-			if (total_size > sizeof(item_buffer)) {
-				LOG_ERR("Combined data too large: %zu > %zu",
-					total_size, sizeof(item_buffer));
+/* Consume the confirmed-sent item from the backend and peek the next one into the pipe. */
+static bool handle_batch_consume(struct storage_state *state_object,
+				 const struct storage_msg *msg)
+{
+	const struct storage_backend *backend = storage_backend_get();
+	uint8_t discard[STORAGE_MAX_DATA_SIZE];
+	int ret;
 
-				return -EIO;
-			}
+	if (msg->session_id != state_object->current_session.session_id) {
+		LOG_WRN("CONSUME session ID mismatch: 0x%X (current: 0x%X), ignoring",
+			msg->session_id, state_object->current_session.session_id);
+		return false;
+	}
 
-			/* Check if exact size fits in remaining pipe buffer space */
-			if (total_bytes_sent + total_size > CONFIG_APP_STORAGE_BATCH_BUFFER_SIZE) {
-				/* Pipe buffer full - stop here without consuming data */
-				LOG_DBG("Pipe buffer full");
+	/* Remove the confirmed-sent item from the backend queue head */
+	bool type_matched = false;
 
-				state_object->current_session.more_data = true;
-
-				break;
-			}
-
-			/* Now that we know it fits, retrieve the data from backend */
-			ret = backend->retrieve(type, data, STORAGE_MAX_DATA_SIZE);
+	STRUCT_SECTION_FOREACH(storage_data, type) {
+		if (type->data_type == msg->data_type) {
+			type_matched = true;
+			ret = backend->retrieve(type, discard, sizeof(discard));
 			if (ret < 0) {
-				LOG_ERR("Failed to retrieve %s data after peek: %d",
-					type->name, ret);
-
-				return -EIO;
+				LOG_ERR("Failed to consume item (type %d): %d, aborting session",
+					msg->data_type, ret);
+				send_batch_error_response(msg->session_id);
+				smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
+				return false;
 			}
-
-			/* Sanity check: retrieved size should match peeked size */
-			__ASSERT_NO_MSG(ret == (int)header->data_size);
-
-			/* Write combined buffer atomically to pipe */
-			ret = pipe_write_all(&storage_pipe, item_buffer, total_size, PUB_TIMEOUT);
-			if (ret < 0) {
-				/* This should never happen since we checked space above */
-				LOG_ERR("Unexpected pipe write failure after space check: %d", ret);
-
-				return -EIO;
-			}
-
-			__ASSERT_NO_MSG(ret == (int)total_size);
-
-			/* Update session progress and byte tracking */
-			state_object->current_session.items_sent++;
-			total_bytes_sent += total_size;
-
-			count--;
+			LOG_DBG("Consumed %s item from backend", type->name);
+			break;
 		}
 	}
 
-	LOG_DBG("Batch population complete for session 0x%X: %zu/%zu items",
-		state_object->current_session.session_id,
-		state_object->current_session.items_sent,
-		state_object->current_session.total_items);
+	if (!type_matched) {
+		LOG_ERR("CONSUME for unknown data_type %d, aborting session", msg->data_type);
+		send_batch_error_response(msg->session_id);
+		smf_set_state(SMF_CTX(state_object), &states[STATE_BUFFER_IDLE]);
+		return false;
+	}
 
-	return 0;
+	/* Peek the next item into the pipe for the consumer */
+	ret = populate_pipe(state_object);
+	if (ret == -ENODATA) {
+		LOG_DBG("All items consumed, pipe empty");
+	} else if (ret < 0) {
+		LOG_ERR("Failed to populate pipe after consume: %d", ret);
+	}
+
+	return true;
 }
 
 /* Start a new batch session.
@@ -622,7 +623,6 @@ static int start_batch_session(struct storage_state *state_object,
 	/* Start new session using requester's session ID */
 	state_object->current_session.session_id = request_msg->session_id;
 	state_object->current_session.total_items = total_items;
-	state_object->current_session.items_sent = 0;
 
 	/* Try to populate the pipe */
 	err = populate_pipe(state_object);
@@ -633,14 +633,11 @@ static int start_batch_session(struct storage_state *state_object,
 		return err;
 	}
 
-	/* Success - pipe populated (fully or partially) */
-	send_batch_available_response(request_msg->session_id,
-				      state_object->current_session.items_sent,
-				      state_object->current_session.more_data);
+	/* Success, one item in pipe, report total available to consumer */
+	send_batch_available_response(request_msg->session_id, total_items);
 
-	LOG_DBG("Started batch session (session_id 0x%X), %zu items in batch (%zu total)",
+	LOG_DBG("Started batch session (session_id 0x%X), %zu items in batch",
 		state_object->current_session.session_id,
-		state_object->current_session.items_sent,
 		total_items);
 
 	return 0;
@@ -879,6 +876,13 @@ static enum smf_state_result state_buffer_pipe_active_run(void *o)
 					msg->session_id, state_object->current_session.session_id);
 			}
 
+			return SMF_EVENT_HANDLED;
+
+		case STORAGE_BATCH_CONSUME:
+			if (handle_batch_consume(state_object, msg)) {
+				k_work_reschedule(&state_object->session_timeout_work,
+						  K_SECONDS(STORAGE_SESSION_TIMEOUT_SECONDS));
+			}
 			return SMF_EVENT_HANDLED;
 
 		case STORAGE_BATCH_REQUEST: {

--- a/app/src/modules/storage/storage.h
+++ b/app/src/modules/storage/storage.h
@@ -66,7 +66,11 @@ enum storage_msg_type {
 	/* Response to a STORAGE_BATCH_REQUEST message. Indicates batch is ready for reading.
 	 * The `data_len` field contains the total number of items available.
 	 * The `session_id` field echoes back the session ID from the request.
-	 * Use storage_batch_read() to consume data from the batch.
+	 *
+	 * Call storage_batch_read() to read the next item from the batch. After the item
+	 * has been confirmed sent, publish STORAGE_BATCH_CONSUME (with the matching
+	 * `session_id` and `data_type`) to remove it from the backend and advance to the
+	 * next item. Reading without consuming will repeatedly return the same head item.
 	 */
 	STORAGE_BATCH_AVAILABLE,
 
@@ -82,6 +86,13 @@ enum storage_msg_type {
 
 	/* Batch is busy - cannot process request at this time. */
 	STORAGE_BATCH_BUSY,
+
+	/* Confirm that a batch item was successfully sent to cloud.
+	 * Must contain `data_type` identifying the type of the item just sent.
+	 * Storage removes the item from the backend queue head and makes the next
+	 * item available in the pipe. Only valid during an active batch session.
+	 */
+	STORAGE_BATCH_CONSUME,
 };
 
 /**
@@ -110,14 +121,7 @@ struct storage_msg {
 	 * - STORAGE_BATCH_AVAILABLE: number of items available in batch
 	 * - STORAGE_DATA: size of flushed data
 	 */
-	uint32_t data_len: 31;
-
-	/* Indicates if there is more data to be read from the batch.
-	 * Valid only for STORAGE_BATCH_AVAILABLE messages.
-	 * This is used by the batch reader to determine if it should continue reading after
-	 * the current batch has been read.
-	 */
-	bool more_data: 1;
+	uint32_t data_len;
 };
 
 /**

--- a/docs/common/getting_started.md
+++ b/docs/common/getting_started.md
@@ -368,8 +368,8 @@ To test that everything is working as expected, complete the following steps:
     [00:00:17.871,215] <dbg> storage: ram_records_count: Counted 1 items in LOCATION ring buffer
     [00:00:17.871,276] <dbg> storage: ram_records_count: Counted 1 items in LOCATION ring buffer
     [00:00:17.871,368] <dbg> storage: ram_retrieve: Retrieved item in LOCATION ring buffer, size: 488 bytes, 0 items left
-    [00:00:17.871,459] <dbg> storage: populate_pipe: Batch population complete for session 0x45CA: 1/1 items
-    [00:00:17.871,978] <dbg> storage: start_batch_session: Started batch session (session_id 0x45CA), 1 items in batch (1 total)
+    [00:00:17.871,459] <dbg> storage: populate_pipe: Pipe populated for session 0x45CA: with LOCATION item (493 bytes)
+    [00:00:17.871,978] <dbg> storage: start_batch_session: Started batch session (session_id 0x45CA), 1 items in batch
     [00:00:17.872,009] <dbg> storage: state_buffer_pipe_active_entry: Batch session started, session_id: 17866
     [00:00:17.872,131] <dbg> storage: state_buffer_pipe_active_run: state_buffer_pipe_active_run
     [00:00:17.872,161] <dbg> storage: state_running_run: state_running_run

--- a/docs/modules/cloud.md
+++ b/docs/modules/cloud.md
@@ -27,10 +27,17 @@ The Cloud module implements a state machine with the following states and transi
 The cloud module subscribes to the `storage_chan` and `storage_data_chan` channels to receive data
 from the storage module.
 It handles `STORAGE_BATCH_AVAILABLE`, `STORAGE_BATCH_EMPTY`, `STORAGE_BATCH_BUSY`, and
-`STORAGE_BATCH_ERROR` messages on the `storage_chan` channel to manage batch data flow, and consumes
-batch items using the `storage_batch_read()` function until the batch is exhausted, then issues
-`STORAGE_BATCH_CLOSE`. It also handles `STORAGE_DATA` messages on the `storage_data_chan` channel to
-forward individual data items to nRF Cloud.
+`STORAGE_BATCH_ERROR` messages on the `storage_chan` channel to manage batch data flow.
+
+For each `STORAGE_BATCH_AVAILABLE` event, the cloud module drains the batch by repeatedly
+calling `storage_batch_read()` and sending each item to nRF Cloud. Reads do not remove items
+from storage; the cloud module publishes `STORAGE_BATCH_CONSUME` only **after** an item has
+been successfully sent, which removes it from the backend and primes the next item. On a
+network send error the session is aborted without consuming the item, so that data is
+retained for the next batch attempt. When the batch is drained (or aborted), the cloud
+module issues `STORAGE_BATCH_CLOSE` to end the session.
+
+It also handles `STORAGE_DATA` messages on the `storage_data_chan` channel to forward individual data items to nRF Cloud.
 
 ## Messages
 

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -41,6 +41,31 @@ The storage module supports two backends:
 Data producing modules publish sampled data to their respective zbus channel.
 Data is stored and later emitted by flush or streamed over the batch pipe, using the batch interface described in the following section.
 
+### Batch session protocol
+
+Batch reads use a consume-on-confirm contract so that an item is only removed
+from the backend after the consumer has confirmed it was processed (for example,
+successfully sent to the cloud). A typical session looks like this:
+
+1. Consumer publishes `STORAGE_BATCH_REQUEST` with a non-zero `session_id`.
+2. Storage replies with `STORAGE_BATCH_AVAILABLE` (with `data_len` set to the
+   number of items available) and primes the pipe with the head item.
+   If there is no data, `STORAGE_BATCH_EMPTY` is sent instead, and the session must still be closed.
+3. Consumer calls `storage_batch_read()` to read the head item. The item is
+   **not** removed from the backend by this call.
+4. After the item has been processed, the consumer publishes
+   `STORAGE_BATCH_CONSUME` with the matching `session_id` and the `data_type`
+   of the item. Storage removes the head item and primes the next one in the
+   pipe.
+5. Steps 3 and 4 are repeated until `storage_batch_read()` returns `-EAGAIN`,
+   or until the consumer decides to stop.
+6. Consumer publishes `STORAGE_BATCH_CLOSE` to end the session.
+
+If the consumer reads without consuming, `storage_batch_read()` will repeatedly
+return the same head item. If a `STORAGE_BATCH_CONSUME` arrives with an
+unknown or mismatched `data_type`, the storage module aborts the session with
+`STORAGE_BATCH_ERROR` to avoid silent stalls.
+
 ### Memory management
 
 This module allocates RAM from the following places, and understanding these helps you tune it down:
@@ -243,6 +268,15 @@ All message types are defined in the `storage.h` file.
   Responds with `STORAGE_BATCH_AVAILABLE`, `STORAGE_BATCH_EMPTY`, `STORAGE_BATCH_BUSY`, or `STORAGE_BATCH_ERROR`.
   Available in both operational modes.
 
+- **STORAGE_BATCH_CONSUME**: Confirms that the head item of an active batch session has been
+  processed (for example, successfully sent to the cloud). The `session_id` must match the
+  active session and `data_type` must identify the type of the item just read with
+  `storage_batch_read()`. Storage removes the item from the backend and makes the next item
+  available in the pipe. An unknown or mismatched `data_type` aborts the session.
+
+- **STORAGE_BATCH_CLOSE**: Ends a batch session. Must be sent for every session, including
+  sessions that received `STORAGE_BATCH_EMPTY` or `STORAGE_BATCH_ERROR`.
+
 - **STORAGE_CLEAR**: Clears all stored data from the backend.
   Available in both operational modes.
 
@@ -283,14 +317,12 @@ The message structure used by the storage module is defined in `storage.h`:
 ```c
 struct storage_msg {
     enum storage_msg_type type;           /* Message type */
-    enum storage_data_type data_type;     /* Data type for STORAGE_DATA */
+    enum storage_data_type data_type;     /* Data type for STORAGE_DATA / STORAGE_BATCH_CONSUME */
     union {
         uint8_t buffer[STORAGE_MAX_DATA_SIZE];
         uint32_t session_id;              /* Batch session id */
-        enum storage_reject_reason reject_reason; /* For MODE_CHANGE_REJECTED */
     };
-    uint32_t data_len: 31;                /* Length or count */
-    bool     more_data: 1;                /* More data available in batch */
+    uint32_t data_len;                    /* Length or count */
 };
 ```
 

--- a/tests/module/cloud/src/cloud_module_test.c
+++ b/tests/module/cloud/src/cloud_module_test.c
@@ -148,8 +148,10 @@ static K_SEM_DEFINE(cloud_connected, 0, 1);
 static K_SEM_DEFINE(data_sent, 0, 1);
 static K_SEM_DEFINE(cloud_module_response_recv_sem, 0, 1);
 static K_SEM_DEFINE(storage_batch_closed, 0, 1);
+static K_SEM_DEFINE(storage_consume_sem, 0, 10);
 static struct cloud_msg last_shadow_response;
 static struct storage_msg last_storage_msg;
+static struct storage_msg last_consume_msg;
 static struct nrf_cloud_gnss_data last_gnss_data;
 
 static nrf_provisioning_event_cb_t handler;
@@ -171,6 +173,7 @@ static int date_time_uptime_to_unix_time_ms_custom_fake(int64_t *unix_time_ms)
 enum fake_batch_mode {
 	FAKE_BATCH_NONE = 0,
 	FAKE_BATCH_BATTERY,
+	FAKE_BATCH_TWO_BATTERY,
 	FAKE_BATCH_ENV,
 };
 
@@ -185,28 +188,66 @@ static int storage_batch_read_custom(struct storage_data_item *out_item, k_timeo
 		return -EAGAIN;
 	}
 
-	if (fake_read_calls++ == 0) {
-		switch (fake_mode) {
-		case FAKE_BATCH_BATTERY:
+	int call = fake_read_calls++;
+
+	switch (fake_mode) {
+	case FAKE_BATCH_BATTERY:
+		if (call == 0) {
 			out_item->type = STORAGE_TYPE_BATTERY;
 			out_item->data.BATTERY.percentage = 87.5;
 			out_item->data.BATTERY.timestamp = TEST_BATTERY_UPTIME_MS;
-			break;
-		case FAKE_BATCH_ENV:
+			return 0;
+		}
+		break;
+	case FAKE_BATCH_TWO_BATTERY:
+		if (call == 0) {
+			out_item->type = STORAGE_TYPE_BATTERY;
+			out_item->data.BATTERY.percentage = 87.5;
+			out_item->data.BATTERY.timestamp = TEST_BATTERY_UPTIME_MS;
+			return 0;
+		} else if (call == 1) {
+			out_item->type = STORAGE_TYPE_BATTERY;
+			out_item->data.BATTERY.percentage = 95.0;
+			out_item->data.BATTERY.timestamp = TEST_BATTERY_UPTIME_MS;
+			return 0;
+		}
+		break;
+	case FAKE_BATCH_ENV:
+		if (call == 0) {
 			out_item->type = STORAGE_TYPE_ENVIRONMENTAL;
 			out_item->data.ENVIRONMENTAL.temperature = 21.5;
 			out_item->data.ENVIRONMENTAL.humidity = 40.0;
 			out_item->data.ENVIRONMENTAL.pressure = 1002.3;
 			out_item->data.ENVIRONMENTAL.timestamp = TEST_ENVIRONMENTAL_UPTIME_MS;
-			break;
-		default:
-			return -EAGAIN;
+			return 0;
 		}
-
-		return 0;
+		break;
+	default:
+		break;
 	}
 
 	return -EAGAIN;
+}
+
+/* Custom fake for nrf_cloud_coap_sensor_send that fails with -EINVAL on the first call
+ * and succeeds (returns 0) on subsequent calls.
+ */
+static int nrf_cloud_coap_sensor_send_fail_first_custom_fake(const char *app_id, double value,
+							     int64_t ts, bool confirmable)
+{
+	ARG_UNUSED(app_id);
+	ARG_UNUSED(value);
+	ARG_UNUSED(ts);
+	ARG_UNUSED(confirmable);
+
+	/* fail_count tracks calls independently of the FFF call_count which is
+	 * incremented before the custom_fake is invoked.
+	 */
+	if (nrf_cloud_coap_sensor_send_fake.call_count == 1) {
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static int nrf_cloud_client_id_get_custom_fake(char *buf, size_t len)
@@ -279,6 +320,9 @@ static void cloud_chan_cb(const struct zbus_channel *chan)
 		if (storage_msg->type == STORAGE_BATCH_CLOSE) {
 			memcpy(&last_storage_msg, storage_msg, sizeof(struct storage_msg));
 			k_sem_give(&storage_batch_closed);
+		} else if (storage_msg->type == STORAGE_BATCH_CONSUME) {
+			memcpy(&last_consume_msg, storage_msg, sizeof(struct storage_msg));
+			k_sem_give(&storage_consume_sem);
 		}
 	}
 }
@@ -420,6 +464,8 @@ void setUp(void)
 	k_sem_reset(&data_sent);
 	k_sem_reset(&cloud_module_response_recv_sem);
 	k_sem_reset(&storage_batch_closed);
+	k_sem_reset(&storage_consume_sem);
+	memset(&last_consume_msg, 0, sizeof(last_consume_msg));
 
 	/* Set default return values */
 	nrf_cloud_coap_location_send_fake.return_val = 0;
@@ -728,7 +774,6 @@ void test_storage_data_battery_sent_to_cloud(void)
 		.type = STORAGE_BATCH_AVAILABLE,
 		.data_len = 1,
 		.session_id = 0xAABBCCDD,
-		.more_data = false,
 	};
 
 	connect_cloud();
@@ -759,7 +804,6 @@ void test_storage_data_environmental_sent_to_cloud(void)
 		.type = STORAGE_BATCH_AVAILABLE,
 		.data_len = 1,
 		.session_id = 0x11223344,
-		.more_data = false,
 	};
 
 	connect_cloud();
@@ -794,7 +838,6 @@ void test_storage_batch_no_items_should_not_update_shadow_network_info(void)
 		.type = STORAGE_BATCH_AVAILABLE,
 		.data_len = 1,
 		.session_id = 0x55667788,
-		.more_data = false,
 	};
 
 	connect_cloud();
@@ -820,7 +863,6 @@ void test_storage_batch_shadow_network_info_update_error_should_still_close_sess
 		.type = STORAGE_BATCH_AVAILABLE,
 		.data_len = 1,
 		.session_id = 0x99AABBCC,
-		.more_data = false,
 	};
 
 	connect_cloud();
@@ -1619,13 +1661,21 @@ static void wait_for_storage_batch_close(k_timeout_t timeout)
 	TEST_ASSERT_EQUAL(0, err);
 }
 
+/* Helper to wait for a STORAGE_BATCH_CONSUME message from the cloud module */
+static void wait_for_consume(k_timeout_t timeout)
+{
+	int err;
+
+	err = k_sem_take(&storage_consume_sem, timeout);
+	TEST_ASSERT_EQUAL(0, err);
+}
+
 void test_storage_batch_available_when_paused_should_close_session(void)
 {
 	struct storage_msg batch_available = {
 		.type = STORAGE_BATCH_AVAILABLE,
 		.data_len = 5,
 		.session_id = 0x12345678,
-		.more_data = false,
 	};
 
 	setup_cloud_paused();
@@ -1727,6 +1777,121 @@ void test_agnss_request_cached_while_disconnected_and_sent_on_connect(void)
 	/* Verify the cached A-GNSS request was sent after connecting */
 	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_agnss_data_get_fake.call_count);
 	TEST_ASSERT_EQUAL(1, location_agnss_data_process_fake.call_count);
+}
+
+/* Verify STORAGE_BATCH_CONSUME is published to storage_chan after each successful send */
+void test_batch_consume_sent_after_successful_send(void)
+{
+	struct storage_msg batch_available = {
+		.type = STORAGE_BATCH_AVAILABLE,
+		.data_len = 1,
+		.session_id = 0x12AB34CD,
+	};
+
+	connect_cloud();
+
+	/* Prepare fake to return one battery item, then -EAGAIN */
+	fake_mode = FAKE_BATCH_BATTERY;
+	fake_read_calls = 0;
+	storage_batch_read_fake.custom_fake = storage_batch_read_custom;
+
+	publish_and_assert(&storage_chan, &batch_available);
+
+	/* CONSUME is published after the successful send */
+	wait_for_consume(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_CONSUME, last_consume_msg.type);
+	TEST_ASSERT_EQUAL(STORAGE_TYPE_BATTERY, last_consume_msg.data_type);
+
+	/* Verify the send was made */
+	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_sensor_send_fake.call_count);
+
+	/* Verify session is closed after processing */
+	wait_for_storage_batch_close(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_storage_msg.session_id);
+}
+
+/* Verify that a permanent/non-network error (-EINVAL) on one batch item drops only
+ * that item via CONSUME (to skip it), and that the batch loop continues to process
+ * remaining items.
+ */
+void test_batch_permanent_error_drops_item_without_requeue(void)
+{
+	struct storage_msg batch_available = {
+		.type = STORAGE_BATCH_AVAILABLE,
+		.data_len = 2,
+		.session_id = 0xABCD1234,
+	};
+
+	connect_cloud();
+
+	/* Setup fake to return two battery items, then -EAGAIN, and configure send to fail with
+	 * -EINVAL for the first item and succeed for the second item
+	 */
+	fake_mode = FAKE_BATCH_TWO_BATTERY;
+	fake_read_calls = 0;
+	storage_batch_read_fake.custom_fake = storage_batch_read_custom;
+	nrf_cloud_coap_sensor_send_fake.custom_fake =
+		nrf_cloud_coap_sensor_send_fail_first_custom_fake;
+
+	publish_and_assert(&storage_chan, &batch_available);
+
+	/* Two CONSUMEs: one to skip the bad item, one for the successful item */
+	wait_for_consume(K_SECONDS(WAIT_TIMEOUT));
+	wait_for_consume(K_SECONDS(WAIT_TIMEOUT));
+
+	/* Session must be closed after processing both items */
+	wait_for_storage_batch_close(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_storage_msg.session_id);
+
+	/* Exactly two CONSUMEs were sent */
+	TEST_ASSERT_EQUAL(0, k_sem_count_get(&storage_consume_sem));
+
+	/* Shadow network info was updated */
+	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_shadow_network_info_update_fake.call_count);
+
+	/* 1 failed send + 1 successful send = 2 total */
+	TEST_ASSERT_EQUAL(2, nrf_cloud_coap_sensor_send_fake.call_count);
+}
+
+/* Verify that a network error (-EIO) causes the batch loop to abort without consuming
+ * the failed item — it stays at the backend head and will be retried next session.
+ */
+void test_batch_network_error_aborts_loop(void)
+{
+	struct storage_msg batch_available = {
+		.type = STORAGE_BATCH_AVAILABLE,
+		.data_len = 2,
+		.session_id = 0xFEEDFACE,
+	};
+	double expected_pct = 87.5;
+
+	connect_cloud();
+
+	/* Setup fake to return two battery items, then -EAGAIN */
+	fake_mode = FAKE_BATCH_TWO_BATTERY;
+	fake_read_calls = 0;
+	storage_batch_read_fake.custom_fake = storage_batch_read_custom;
+	/* Network send fails with -EIO */
+	nrf_cloud_coap_sensor_send_fake.return_val = -EIO;
+
+	publish_and_assert(&storage_chan, &batch_available);
+
+	/* Session should be closed — no CONSUME sent for network errors */
+	wait_for_storage_batch_close(K_SECONDS(WAIT_TIMEOUT));
+	TEST_ASSERT_EQUAL(batch_available.session_id, last_storage_msg.session_id);
+
+	/* No CONSUME was sent — failed item stays at backend head for next session */
+	TEST_ASSERT_EQUAL(0, k_sem_count_get(&storage_consume_sem));
+
+	/* No items were successfully delivered, so shadow network info should not be updated */
+	TEST_ASSERT_EQUAL(0, nrf_cloud_coap_shadow_network_info_update_fake.call_count);
+
+	/* Loop should have aborted after the failure, only one send should have been attempted */
+	TEST_ASSERT_EQUAL(1, nrf_cloud_coap_sensor_send_fake.call_count);
+	/* Verify it was the first item (87.5%) — memcmp avoids Unity double support requirement */
+	TEST_ASSERT_EQUAL_MEMORY(&expected_pct,
+				 &nrf_cloud_coap_sensor_send_fake.arg1_history[0],
+				 sizeof(double));
 }
 
 /* This is required to be added to each test. That is because unity's

--- a/tests/module/storage/src/storage_module_test.c
+++ b/tests/module/storage/src/storage_module_test.c
@@ -174,9 +174,13 @@ static void storage_chan_cb(const struct zbus_channel *chan)
 	}
 }
 
-static size_t read_batch_data(size_t expected_item_count)
+static size_t read_batch_data(size_t expected_item_count, uint32_t session_id)
 {
 	struct storage_data_item tmp;
+	struct storage_msg consume_msg = {
+		.type = STORAGE_BATCH_CONSUME,
+		.session_id = session_id,
+	};
 	size_t items_read = 0;
 
 	while (items_read < expected_item_count) {
@@ -188,6 +192,12 @@ static size_t read_batch_data(size_t expected_item_count)
 		}
 
 		TEST_ASSERT_EQUAL(0, ret);
+
+		/* Confirm the send: removes item from backend queue head and
+		 * makes the next item available in the pipe.
+		 */
+		consume_msg.data_type = tmp.type;
+		(void)zbus_chan_pub(&storage_chan, &consume_msg, K_SECONDS(1));
 
 		items_read++;
 
@@ -473,7 +483,7 @@ void test_storage_batch_request_and_retrieve(void)
 	/* Verify we have data available, but don't assume exact count due to buffer limits */
 	TEST_ASSERT_GREATER_THAN(0, received_msg.data_len);
 
-	items_read = read_batch_data(received_msg.data_len);
+	items_read = read_batch_data(received_msg.data_len, received_msg.session_id);
 
 	for (size_t i = 0; i < items_read; i++) {
 		TEST_ASSERT_EQUAL_DOUBLE(env_samples[i].temperature,
@@ -543,10 +553,10 @@ void test_storage_batch_request_multiple(void)
 		/* The data_len reflects items available in batch buffer for this request */
 		TEST_ASSERT_GREATER_THAN(0, received_msg.data_len);
 
-		samples_received = read_batch_data(received_msg.data_len);
+		samples_received = read_batch_data(received_msg.data_len, request_msg.session_id);
 
-		/* Compare received samples iteratively - storage consumes data
-		 * destructively, so we expect samples in sequence: first iteration
+		/* Compare received samples iteratively - storage consumes items on
+		 * confirm, so we expect samples in sequence: first iteration
 		 * gets 0-15, second gets 16-31, etc.
 		 */
 		for (size_t i = 0; i < samples_received; i++) {
@@ -669,12 +679,12 @@ void test_storage_batch_request_mixed_data(void)
 		/* Don't assume batch can fit all remaining data - just verify we got some */
 		TEST_ASSERT_GREATER_THAN(0, received_msg.data_len);
 
-		items_read = read_batch_data(received_msg.data_len);
+		items_read = read_batch_data(received_msg.data_len, batch_msg.session_id);
 
-		/* Verify received data matches expected values based on destructive
-		 * consumption. Since storage consumes data destructively, we expect
-		 * samples in sequence: first iteration gets samples 0-N, second gets
-		 * N+1-M, etc.
+		/* Verify received data matches expected values based on consume-on-confirm
+		 * behavior. Since storage consumes items only after the consumer confirms
+		 * each one, we expect samples in sequence: first iteration gets samples
+		 * 0-N, second gets N+1-M, etc.
 		 */
 		for (size_t i = 0; i < received_battery_samples_count; i++) {
 			size_t expected_idx = total_battery_received + i;
@@ -930,7 +940,7 @@ void test_storage_stores_samples_while_batch_session_active(void)
 
 	memset(&received_env_samples, 0, sizeof(received_env_samples));
 
-	items_read = read_batch_data(received_msg.data_len);
+	items_read = read_batch_data(received_msg.data_len, first_request.session_id);
 
 	TEST_ASSERT_EQUAL(1, items_read);
 
@@ -953,7 +963,7 @@ void test_storage_stores_samples_while_batch_session_active(void)
 
 	memset(&received_env_samples, 0, sizeof(received_env_samples));
 
-	items_read = read_batch_data(received_msg.data_len);
+	items_read = read_batch_data(received_msg.data_len, received_msg.session_id);
 
 	TEST_ASSERT_EQUAL(3, items_read);
 
@@ -1085,6 +1095,60 @@ void test_storage_threshold(void)
 	/* Verify we did NOT get STORAGE_THRESHOLD_REACHED message since threshold is now high */
 	TEST_ASSERT_NOT_EQUAL(STORAGE_THRESHOLD_REACHED, received_msg.type);
 
+}
+
+/* Verify that items not confirmed via STORAGE_BATCH_CONSUME are retained at the
+ * backend queue head and appear again in the next batch session.
+ */
+void test_storage_unconsumed_item_retained_on_session_close(void)
+{
+	struct environmental_msg env_msg = {
+		.type = ENVIRONMENTAL_SENSOR_SAMPLE_RESPONSE,
+	};
+	struct storage_data_item item;
+	uint32_t session_id;
+	size_t items_read;
+	const uint8_t num_samples = 3;
+	int ret;
+
+	/* Store multiple environmental samples */
+	for (size_t i = 0; i < num_samples; i++) {
+		populate_env_message(i, &env_msg);
+		publish_and_assert(&environmental_chan, &env_msg);
+	}
+
+	/* Open a batch session — one item is peeked into the pipe */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	TEST_ASSERT_EQUAL(num_samples, received_msg.data_len);
+	session_id = received_msg.session_id;
+
+	/* Read the item but do NOT send CONSUME — item stays at the backend head */
+	ret = storage_batch_read(&item, K_SECONDS(5));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Close without consuming: backend is unchanged */
+	close_batch_and_assert(session_id);
+	k_sleep(K_MSEC(500));
+
+	/* Reset counters before the next batch read */
+	received_env_samples_count = 0;
+	memset(&received_env_samples, 0, sizeof(received_env_samples));
+
+	/* All items must still be present in the next batch */
+	request_batch_and_assert();
+	k_sleep(K_SECONDS(1));
+
+	TEST_ASSERT_EQUAL(STORAGE_BATCH_AVAILABLE, received_msg.type);
+	TEST_ASSERT_EQUAL(num_samples, received_msg.data_len);
+
+	/* Read and consume all items */
+	items_read = read_batch_data(received_msg.data_len, received_msg.session_id);
+	TEST_ASSERT_EQUAL(num_samples, items_read);
+
+	close_batch_and_assert(received_msg.session_id);
 }
 
 extern int unity_main(void);

--- a/tests/on_target/tests/test_functional/test_buffer_flash.py
+++ b/tests/on_target/tests/test_functional/test_buffer_flash.py
@@ -86,16 +86,15 @@ def test_buffer_flash(dut_cloud, hex_file_buffer_flash):
         start_pos = dut_cloud.uart.get_size()
         dut_cloud.uart.wait_for_str(get_storing_str("LOCATION", file_index=1), timeout=300, start_pos=start_pos)
 
-        # Wait for buffer processing, expecting 30 items to be stored total ((BATTERY, ENVIRONMENTAL, LOCATION) x 10 samples)
-        # NOTE: If default sampling behavior changes (e.g. additional types) this needs to be updated to match expected total samples
-        start_pos = dut_cloud.uart.get_size()
-        dut_cloud.uart.wait_for_str_re(
-            r"Batch population complete for session 0x[0-9A-F]+: \d+/30 items",
+        # Wait for buffer processing and pipe exit using the same start_pos captured before the rollover.
+        # Avoids a race where "All items consumed" or "state_buffer_pipe_active_exit" is logged between
+        # the rollover detection and a new get_size() call, which would cause the search to miss them.
+        dut_cloud.uart.wait_for_str(
+            "All items consumed, pipe empty",
             timeout=300,
             start_pos=start_pos,
         )
 
-        start_pos = dut_cloud.uart.get_size()
         dut_cloud.uart.wait_for_str("state_buffer_pipe_active_exit", timeout=120, start_pos=start_pos)
 
         # Capture write and read offsets before reboot (only using LOCATION as all types should be in sync)

--- a/tests/on_target/tests/test_functional/test_buffer_ram.py
+++ b/tests/on_target/tests/test_functional/test_buffer_ram.py
@@ -22,8 +22,11 @@ RAM_BUFFER_TEST_STORAGE_THRESHOLD = 10
 def get_initialized_str(datatype):
     return f"Ring buffer {datatype} initialized with size"
 
-def get_storing_str(datatype):
-    return f"Stored {datatype} item, count: 1"
+def get_storing_str(datatype, count=None):
+    if count is None:
+        return f"Stored {datatype} item, count:"
+    else:
+        return f"Stored {datatype} item, count: {count}"
 
 @pytest.mark.slow
 def test_buffer_ram(dut_cloud, hex_file_buffer_ram):
@@ -50,6 +53,12 @@ def test_buffer_ram(dut_cloud, hex_file_buffer_ram):
                 get_initialized_str("LOCATION")
         ]
 
+        first_storing_list = [
+                get_storing_str("ENVIRONMENTAL", 1),
+                get_storing_str("BATTERY", 1),
+                get_storing_str("LOCATION", 1)
+        ]
+
         storing_list = [
                 get_storing_str("ENVIRONMENTAL"),
                 get_storing_str("BATTERY"),
@@ -63,17 +72,16 @@ def test_buffer_ram(dut_cloud, hex_file_buffer_ram):
         dut_cloud.uart.wait_for_str(initialization_list, timeout=60)
 
         # wait for initial storage
-        dut_cloud.uart.wait_for_str(storing_list, timeout=60)
+        dut_cloud.uart.wait_for_str(first_storing_list, timeout=60)
 
-        # Wait for buffer processing, expecting 30 items to be stored total ((BATTERY, ENVIRONMENTAL, LOCATION) x 10 samples)
-        dut_cloud.uart.wait_for_str_re(r"Batch population complete for session 0x[0-9A-F]+: \d+/30 items", timeout=500)
+        # Wait for buffer processing, expecting all 30 items to be consumed ((BATTERY, ENVIRONMENTAL, LOCATION) x 10 samples)
+        dut_cloud.uart.wait_for_str("All items consumed, pipe empty", timeout=500)
 
         # Wait for buffer processing to complete
-        dut_cloud.uart.wait_for_str("state_buffer_pipe_active_exit", timeout=60)
+        pipe_exit_pos = dut_cloud.uart.wait_for_str("state_buffer_pipe_active_exit", timeout=60)
 
-        # Wait for next sample after buffer processing, expecting count to be back to 1
-        dut_cloud.uart.flush()
-        dut_cloud.uart.wait_for_str(storing_list, timeout=60)
+        # Wait for next sample after buffer processing, verifying the device continues storing new items
+        dut_cloud.uart.wait_for_str(storing_list, timeout=120, start_pos=pipe_exit_pos)
     finally:
         # Restore default config
         dut_cloud.cloud.patch_config(


### PR DESCRIPTION
Modify storage module to keep data in the backend until cloud confirms that an item has been sent. This allows for better handling of failed sends, as the data will still be available in storage for retrying.