### PR TITLE
modules: location: remove redundant `date_time_now` call

### DIFF
--- a/app/src/modules/cloud/cloud_location.c
+++ b/app/src/modules/cloud/cloud_location.c
@@ -10,7 +10,6 @@
 #include <net/nrf_cloud_coap.h>
 #include <net/nrf_cloud_rest.h>
 #include <zephyr/net/coap.h>
-#include <date_time.h>
 
 #include "cloud_location.h"
 #include "cloud_internal.h"
@@ -261,20 +260,12 @@ static void handle_agnss_request(const struct nrf_modem_gnss_agnss_data_frame *r
 static int handle_gnss_location_data(const struct location_msg *location_msg)
 {
 	int err;
-	int64_t timestamp_ms = NRF_CLOUD_NO_TIMESTAMP;
 	bool confirmable = IS_ENABLED(CONFIG_APP_CLOUD_CONFIRMABLE_MESSAGES);
 	const struct location_data *location_data = &location_msg->gnss_data;
 
-	/* Convert uptime to unix time */
-	timestamp_ms = location_msg->timestamp;
-	err = date_time_uptime_to_unix_time_ms(&timestamp_ms);
-	if (err) {
-		LOG_ERR("date_time_uptime_to_unix_time_ms, error: %d", err);
-	}
-
 	struct nrf_cloud_gnss_data gnss_data = {
 		.type = NRF_CLOUD_GNSS_TYPE_PVT,
-		.ts_ms = timestamp_ms,
+		.ts_ms = location_msg->timestamp,
 		.pvt = {
 			.lat = location_data->latitude,
 			.lon = location_data->longitude,

--- a/tests/module/cloud/src/cloud_module_test.c
+++ b/tests/module/cloud/src/cloud_module_test.c
@@ -161,6 +161,7 @@ static nrf_provisioning_event_cb_t handler;
 #define TEST_BATTERY_UPTIME_MS 5000LL
 #define TEST_ENVIRONMENTAL_UPTIME_MS 10000LL
 #define TEST_LOCATION_UPTIME_MS 20000LL
+#define TEST_LOCATION_UNIX_MS (TEST_LOCATION_UPTIME_MS + TEST_UPTIME_TO_UNIX_OFFSET_MS)
 
 static int date_time_uptime_to_unix_time_ms_custom_fake(int64_t *unix_time_ms)
 {
@@ -736,7 +737,7 @@ void test_gnss_location_data_handling(void)
 	struct location_msg location_msg = {
 		.type = LOCATION_GNSS_DATA,
 		.gnss_data = mock_location,
-		.timestamp = TEST_LOCATION_UPTIME_MS
+		.timestamp = TEST_LOCATION_UNIX_MS
 	};
 	struct storage_msg storage_data_msg = {
 		.type = STORAGE_DATA,
@@ -763,8 +764,7 @@ void test_gnss_location_data_handling(void)
 
 	/* Verify the function was called with valid arguments and correct timestamp */
 	if (nrf_cloud_coap_location_send_fake.call_count > 0) {
-		TEST_ASSERT_EQUAL(TEST_LOCATION_UPTIME_MS + TEST_UPTIME_TO_UNIX_OFFSET_MS,
-				  last_gnss_data.ts_ms);
+		TEST_ASSERT_EQUAL(TEST_LOCATION_UNIX_MS, last_gnss_data.ts_ms);
 	}
 }
 


### PR DESCRIPTION
The timestamp is already converted before sending in the cloud module.