### PR TITLE
.github: workflows: add cleanup job and bump action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  cleanup:
+    runs-on: build_self_hosted
+    steps:
+      - name: Prune old Docker resources
+        run: docker system prune --force --filter "until=48h"
+
+      - name: Remove stale runner temp entries
+        run: |
+          # GitHub Actions stores per-job temp files under _work/_temp.
+          runner_temp_root="$(dirname "${RUNNER_TEMP}")"
+          find "$runner_temp_root" -mindepth 1 -maxdepth 1 -mmin +2880 \
+            ! -path "$RUNNER_TEMP" \
+            -exec rm -rf {} + 2>/dev/null || true
+
   build:
+    needs: cleanup
     runs-on: build_self_hosted
     container: ghcr.io/zephyrproject-rtos/ci:v0.28.7
     env:
@@ -124,7 +139,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: asset-tracker-template
 
@@ -345,7 +360,7 @@ jobs:
           path: ${{ github.workspace }}/size-comment.md
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: firmware-artifacts-att
           path: artifacts/*

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -22,7 +22,7 @@ jobs:
           pip install west gitlint
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: asset-tracker-template
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lychee link checker
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -27,14 +27,14 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /opt/toolchains
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           path: asset-tracker-template
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload Twister Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: twister-results
           path: |


### PR DESCRIPTION
Add a `cleanup` job to `build.yml` that prunes old Docker resources and stale runner temp files before the build runs.

Bump `actions/checkout` to v6 and `actions/upload-artifact` to v6 across all workflows.