### PR TITLE
app: dts: tests: fix nightly

### DIFF
--- a/app/dts/att_flash_partitions.dtsi
+++ b/app/dts/att_flash_partitions.dtsi
@@ -29,7 +29,7 @@
 / {
 	chosen {
 		zephyr,settings-partition = &settings_storage;
-		fmfu_storage = &fmfu_storage_partition;
+		nordic,fmfu-storage-partition = &fmfu_storage_partition;
 		nordic,memfault-coredump-partition = &memfault_coredump_partition;
 	};
 

--- a/tests/on_target/tests/test_functional/test_buffer_flash.py
+++ b/tests/on_target/tests/test_functional/test_buffer_flash.py
@@ -69,8 +69,12 @@ def test_buffer_flash(dut_cloud, hex_file_buffer_flash):
         reset_device()
         start_pos = dut_cloud.uart.get_size()
 
-        # Wait for storage automount
-        dut_cloud.uart.wait_for_str("Automount /att_storage succeeded", timeout=60, start_pos=start_pos)
+        # Wait for storage mount (Zephyr fstab automount logs via littlefs or lfs_backend)
+        dut_cloud.uart.wait_for_str(
+            ["/att_storage mounted", "/att_storage already mounted"],
+            timeout=60,
+            start_pos=start_pos,
+        )
 
         # Clear buffer
         start_pos = dut_cloud.uart.get_size()

--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -95,7 +95,7 @@ def trigger_fota_poll(dut_fota, max_attempts=3):
     for i in range(max_attempts):
         try:
             time.sleep(10)
-            dut_fota.uart.write("att_button press 1\r\n")
+            dut_fota.uart.write("att_fota poll\r\n")
             dut_fota.uart.wait_for_str("nrf_cloud_fota_poll: Starting FOTA download", timeout=30)
             return
         except AssertionError:
@@ -185,7 +185,7 @@ def run_fota_reschedule(dut_fota, fota_type):
     for i in range(3):
         try:
             time.sleep(30)
-            dut_fota.uart.write("att_button press 1\r\n")
+            dut_fota.uart.write("att_fota poll\r\n")
             dut_fota.uart.wait_for_str("nrf_cloud_fota_poll: Starting FOTA download")
             break
         except AssertionError:
@@ -269,7 +269,7 @@ def run_fota_fixture(dut_fota, hex_file, reschedule=False):
             for i in range(3):
                 try:
                     time.sleep(10)
-                    dut_fota.uart.write("att_button press 1\r\n")
+                    dut_fota.uart.write("att_fota poll\r\n")
                     dut_fota.uart.wait_for_str("nrf_cloud_fota_poll: Starting FOTA download", timeout=30)
                     break
                 except AssertionError:


### PR DESCRIPTION
Update `fmfu_storage` chosen property to use the upstream `nordic,fmfu-storage-partition` binding name.

Replace `att_button press 1` with `att_fota poll` command for triggering FOTA in tests, and update storage mount log string to match current Zephyr/littlefs output.