### PR TITLE
.github: Switch to `dorny/test-reporter` and add CI log groups

### DIFF
--- a/.github/workflows/build-and-target-test.yml
+++ b/.github/workflows/build-and-target-test.yml
@@ -215,6 +215,7 @@ jobs:
   test:
     permissions:
       actions: read
+      checks: write
       contents: write
       packages: read
     uses: ./.github/workflows/target-test.yml

--- a/.github/workflows/ncsref-update.yaml
+++ b/.github/workflows/ncsref-update.yaml
@@ -21,6 +21,7 @@ jobs:
   test:
     permissions:
       actions: read
+      checks: write
       contents: write
       packages: read
     uses: ./.github/workflows/target-test.yml

--- a/.github/workflows/target-test.yml
+++ b/.github/workflows/target-test.yml
@@ -91,6 +91,7 @@ jobs:
     name: Target Test - ${{ matrix.device }}
     permissions:
       actions: read
+      checks: write
       contents: write
       packages: read
     container:
@@ -108,12 +109,12 @@ jobs:
           echo "Inside Container - Runner Serial Number: ${{ env.RUNNER_SERIAL_NUMBER }}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: asset-tracker-template
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: firmware-artifacts-att
           path: asset-tracker-template/tests/on_target/artifacts
@@ -200,16 +201,19 @@ jobs:
 
       - name: Results
         if: always()
-        uses: pmeier/pytest-results-action@v0.7.1
+        uses: dorny/test-reporter@v3
         with:
-          path: asset-tracker-template/tests/on_target/results/*.xml
-          summary: true
+          name: ATT FW Test Results - ${{ matrix.device }}
+          working-directory: asset-tracker-template
+          path: tests/on_target/results/*.xml
+          reporter: java-junit
           fail-on-empty: true
-          title: ATT FW Test Results - ${{ matrix.device }}
+          use-actions-summary: true
+          report-title: ATT FW Test Results - ${{ matrix.device }}
 
       - name: Create Report Artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         id: artifact-report
         with:
           name: test-report-${{ matrix.device }}
@@ -218,7 +222,7 @@ jobs:
 
       - name: Push log files to artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         id: artifact-upload-test-logs
         with:
           name: test-logs-${{ matrix.device }}

--- a/tests/on_target/tests/conftest.py
+++ b/tests/on_target/tests/conftest.py
@@ -23,6 +23,7 @@ UART_ID = os.getenv('UART_ID', SEGGER)
 DEVICE_UUID = os.getenv('UUID')
 NRFCLOUD_API_KEY = os.getenv('NRFCLOUD_API_KEY')
 DUT_DEVICE_TYPE = os.getenv('DUT_DEVICE_TYPE')
+_GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS') == 'true'
 
 def get_uarts():
     # Handle platform-specific serial device paths
@@ -57,11 +58,16 @@ def scan_log_for_assertions(log):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logstart(nodeid, location):
+    if _GITHUB_ACTIONS:
+        # Workflow commands must be bare stdout lines (not via the logger).
+        print(f"::group::{nodeid}", flush=True)
     logger.info(f"Starting test: {nodeid}")
 
 @pytest.hookimpl(trylast=True)
 def pytest_runtest_logfinish(nodeid, location):
     logger.info(f"Finished test: {nodeid}")
+    if _GITHUB_ACTIONS:
+        print("::endgroup::", flush=True)
 
 @pytest.fixture(scope="session", autouse=True)
 def _purge_pending_fota_jobs():


### PR DESCRIPTION
Replace `pmeier/pytest-results-action` with `dorny/test-reporter` for better test reporting, and add `checks: write` permission.

Add GitHub Actions log group annotations around each test in `conftest.py` to improve log readability in CI.