### PR TITLE
tests: on_target: consolidate FOTA status and detail waiting

### DIFF
--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -45,21 +45,59 @@ APP_FOTA_TIMEOUT = 60 * 15
 BOOTLOADER_FOTA_TIMEOUT = 60 * 20
 FULL_MFW_FOTA_TIMEOUT = 60 * 30
 
-def await_nrfcloud(func, expected, field, timeout):
+def await_nrfcloud(func, expected, field, timeout, expected_detail=None):
     start = time.time()
-    logger.info(f"Awaiting {field} == {expected} in nrfcloud shadow...")
+    if expected_detail is not None:
+        logger.info(
+            f"Awaiting {field} == {expected} and "
+            f"statusDetail == '{expected_detail}' in nrfcloud..."
+        )
+    else:
+        logger.info(f"Awaiting {field} == {expected} in nrfcloud shadow...")
     while True:
         time.sleep(5)
         if time.time() - start > timeout:
+            if expected_detail is not None:
+                try:
+                    data = func()
+                    if isinstance(data, dict):
+                        status = data.get("status", "<missing>")
+                        status_detail = data.get("statusDetail", "<missing>")
+                    else:
+                        status = data
+                        status_detail = "<unexpected response type>"
+                except Exception as e:
+                    status = f"<failed to fetch: {e}>"
+                    status_detail = status
+                raise RuntimeError(
+                    f"Timeout awaiting {field} == {expected} with "
+                    f"statusDetail == '{expected_detail}'. "
+                    f"Got status: {status!r}, statusDetail: {status_detail!r}")
             raise RuntimeError(f"Timeout awaiting {field} update")
         try:
             data = func()
         except Exception as e:
             logger.warning(f"Exception {e} during waiting for {field}")
             continue
-        logger.debug(f"Reported {field}: {data}")
-        if expected in data:
-            break
+        if expected_detail is not None:
+            if not isinstance(data, dict):
+                logger.warning(
+                    f"Expected dict response when checking statusDetail, got {type(data)}")
+                continue
+            status = data.get("status")
+            status_detail = data.get("statusDetail")
+            logger.debug(
+                f"Reported {field}: status={status!r}, statusDetail={status_detail!r}")
+            if status is not None and expected in status and status_detail == expected_detail:
+                break
+            if status is not None and expected in status:
+                logger.warning(
+                    f"{field} matched {expected!r} but unexpected statusDetail: "
+                    f"{status_detail!r}")
+        else:
+            logger.debug(f"Reported {field}: {data}")
+            if expected in data:
+                break
 
 def await_fota_job_succeeded(dut_fota, job_id, timeout):
     """Wait for FOTA job to complete and the device execution to succeed."""
@@ -76,39 +114,12 @@ def await_fota_job_succeeded(dut_fota, job_id, timeout):
         timeout
     )
     await_nrfcloud(
-        functools.partial(
-            dut_fota.fota.get_fota_execution_status, dut_fota.device_id, job_id),
+        functools.partial(dut_fota.fota.get_fota_execution, dut_fota.device_id, job_id),
         "SUCCEEDED",
         "FOTA execution status",
-        timeout
+        timeout,
+        expected_detail=FOTA_STATUS_DETAIL_SUCCESS,
     )
-
-    start = time.time()
-    logger.info(
-        f"Awaiting FOTA statusDetail == '{FOTA_STATUS_DETAIL_SUCCESS}' in nrfcloud job execution..."
-    )
-    while True:
-        time.sleep(5)
-        if time.time() - start > timeout:
-            try:
-                status_detail = dut_fota.fota.get_fota_execution_status_detail(
-                    dut_fota.device_id, job_id)
-            except Exception as e:
-                status_detail = f"<failed to fetch statusDetail: {e}>"
-            raise RuntimeError(
-                f"Timeout awaiting FOTA statusDetail == '{FOTA_STATUS_DETAIL_SUCCESS}'. "
-                f"Got: {status_detail!r}")
-        try:
-            status_detail = dut_fota.fota.get_fota_execution_status_detail(
-                dut_fota.device_id, job_id)
-        except Exception as e:
-            logger.warning(f"Exception {e} during waiting for FOTA statusDetail")
-            continue
-        logger.debug(f"Reported FOTA statusDetail: {status_detail!r}")
-        if status_detail == FOTA_STATUS_DETAIL_SUCCESS:
-            break
-        logger.warning(
-            f"Unexpected FOTA statusDetail while waiting for success: {status_detail!r}")
 
 def get_appversion(dut_fota):
     shadow = dut_fota.fota.get_device(dut_fota.device_id)

--- a/tests/on_target/utils/nrfcloud.py
+++ b/tests/on_target/utils/nrfcloud.py
@@ -416,13 +416,17 @@ class NRFCloudFOTA(NRFCloud):
         """Returns the number of completed executions for a FOTA job"""
         return self._get(f"/fota-jobs/{job_id}")["executionStats"]["completedExecutions"]
 
+    def get_fota_execution(self, device_id: str, job_id: str) -> dict:
+        """Get FOTA execution for a specific device and job"""
+        return self._get(f"/fota-job-executions/{device_id}/{job_id}")
+
     def get_fota_execution_status(self, device_id: str, job_id: str) -> str:
         """Get FOTA execution status for a specific device and job"""
-        return self._get(f"/fota-job-executions/{device_id}/{job_id}")["status"]
+        return self.get_fota_execution(device_id, job_id)["status"]
 
     def get_fota_execution_status_detail(self, device_id: str, job_id: str) -> str:
         """Get FOTA execution status detail for a specific device and job"""
-        return self._get(f"/fota-job-executions/{device_id}/{job_id}")["statusDetail"]
+        return self.get_fota_execution(device_id, job_id)["statusDetail"]
 
     def post_fota_job(self, uuid: str, fw_id: str) -> Union[str, None]:
         """


### PR DESCRIPTION
Merge the separate `statusDetail` polling loop into `await_nrfcloud` by adding an `expected_detail` parameter. Switch to `get_fota_execution` so status and detail are fetched in one call, reducing duplication and improving timeout error messages.