### PR TITLE
tests: on_target: clean up pending FOTA jobs before and after tests

### DIFF
--- a/tests/on_target/tests/conftest.py
+++ b/tests/on_target/tests/conftest.py
@@ -79,6 +79,12 @@ def dut_board():
     log_uart_string = all_uarts[0]
     uart = Uart(log_uart_string, timeout=UART_TIMEOUT)
 
+    if NRFCLOUD_API_KEY and DEVICE_UUID:
+        try:
+            NRFCloudFOTA(api_key=NRFCLOUD_API_KEY).ensure_no_pending_fota_jobs(DEVICE_UUID)
+        except Exception as e:
+            logger.warning(f"Failed to purge pending FOTA jobs at test start: {e}")
+
     yield types.SimpleNamespace(
         uart=uart,
         device_type=DUT_DEVICE_TYPE
@@ -87,6 +93,12 @@ def dut_board():
     uart_log = uart.whole_log
     uart.stop()
     recover_device()
+
+    if NRFCLOUD_API_KEY and DEVICE_UUID:
+        try:
+            NRFCloudFOTA(api_key=NRFCLOUD_API_KEY).ensure_no_pending_fota_jobs(DEVICE_UUID)
+        except Exception as e:
+            logger.warning(f"Failed to purge pending FOTA jobs at test end: {e}")
 
     scan_log_for_assertions(uart_log)
 

--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -153,6 +153,38 @@ def await_bootloader_version(dut_fota, expected, timeout=DEVICE_MSG_TIMEOUT):
         if version == expected:
             return
 
+def restore_device_after_modem_fota(dut_fota, hex_file):
+    """Return the DUT to a known-good state after modem FOTA tests."""
+    logger.info("Restoring device after modem FOTA test")
+
+    job_id = dut_fota.data.get("job_id")
+    if job_id:
+        try:
+            dut_fota.fota.cancel_fota_job(job_id)
+        except Exception as e:
+            logger.warning(f"Failed to cancel active FOTA job {job_id}: {e}")
+
+    try:
+        dut_fota.fota.ensure_no_pending_fota_jobs(dut_fota.device_id)
+    except Exception as e:
+        logger.warning(f"Failed to cancel pending FOTA jobs during restore: {e}")
+
+    flash_device(os.path.abspath(MFW_FILEPATH))
+    flash_device(os.path.abspath(hex_file))
+
+    try:
+        dut_fota.uart.xfactoryreset()
+        dut_fota.uart.flush()
+    except Exception as e:
+        logger.warning(f"Factory reset during restore failed: {e}")
+
+    reset_device()
+
+    try:
+        dut_fota.fota.ensure_no_pending_fota_jobs(dut_fota.device_id)
+    except Exception as e:
+        logger.warning(f"Failed to cancel pending FOTA jobs after restore: {e}")
+
 def trigger_fota_poll(dut_fota, max_attempts=3):
     for _ in range(max_attempts):
         try:
@@ -411,7 +443,7 @@ def test_bootloader_fota(dut_fota, hex_file):
     finally:
         flash_device(os.path.abspath(hex_file))
 
-def test_delta_mfw_fota(run_fota_fixture):
+def test_delta_mfw_fota(dut_fota, run_fota_fixture, hex_file):
     '''
     Test delta modem FOTA on nrf9151
     '''
@@ -422,11 +454,10 @@ def test_delta_mfw_fota(run_fota_fixture):
             new_version=MFW_DELTA_VERSION_FOTA_TEST
         )
     finally:
-        # Restore mfw, no matter if test pass/fails
-        flash_device(os.path.abspath(MFW_FILEPATH))
+        restore_device_after_modem_fota(dut_fota, hex_file)
 
 @pytest.mark.slow
-def test_full_mfw_fota(run_fota_fixture):
+def test_full_mfw_fota(dut_fota, run_fota_fixture, hex_file):
     '''
     Test full modem FOTA on nrf9151
     '''
@@ -440,5 +471,4 @@ def test_full_mfw_fota(run_fota_fixture):
             reschedule=True
         )
     finally:
-        # Restore mfw, no matter if test pass/fails
-        flash_device(os.path.abspath(MFW_FILEPATH))
+        restore_device_after_modem_fota(dut_fota, hex_file)


### PR DESCRIPTION
Purge any pending FOTA jobs at the start and end of each test session in `conftest.py` to prevent leftover jobs from interfering with runs.

Extract `restore_device_after_modem_fota` to handle full cleanup after modem FOTA tests — cancels active jobs, clears pending ones, reflashes firmware, and does a factory reset.