### PR TITLE
tests: on_target: test_fota: raise on unexpected statusDetail

### DIFF
--- a/tests/on_target/tests/test_functional/test_fota.py
+++ b/tests/on_target/tests/test_functional/test_fota.py
@@ -88,12 +88,12 @@ def await_nrfcloud(func, expected, field, timeout, expected_detail=None):
             status_detail = data.get("statusDetail")
             logger.debug(
                 f"Reported {field}: status={status!r}, statusDetail={status_detail!r}")
-            if status is not None and expected in status and status_detail == expected_detail:
-                break
             if status is not None and expected in status:
-                logger.warning(
+                if status_detail == expected_detail:
+                    break
+                raise RuntimeError(
                     f"{field} matched {expected!r} but unexpected statusDetail: "
-                    f"{status_detail!r}")
+                    f"{status_detail!r} (expected {expected_detail!r})")
         else:
             logger.debug(f"Reported {field}: {data}")
             if expected in data:


### PR DESCRIPTION
`await_nrfcloud` now raises `RuntimeError` instead of just logging a warning when `statusDetail` doesn't match the expected value, making test failures more visible and explicit.