### PR TITLE
app: boards: fix trailer_partition offsets

### DIFF
--- a/app/boards/att_flash_partitions.dtsi
+++ b/app/boards/att_flash_partitions.dtsi
@@ -105,10 +105,17 @@
 					reg = <0xc0000 0x4000>;
 				};
 
-				trailer_partition: partition@f8000 {
+				/*
+				 * MCUboot computes its trailer offset from the end of
+				 * slot0_partition (flash_area size - boot_trailer_sz()); it
+				 * never reads this node. This partition exists purely to mark
+				 * that region as reserved in the layout. 16 KiB is reserved for
+				   the trailer, actual size may be smaller (typically ~ 6 KiB).
+				 */
+				trailer_partition: partition@c4000 {
 					compatible = "zephyr,mapped-partition";
 					label = "trailer";
-					reg = <0xf8000 0x4000>;
+					reg = <0xc4000 0x4000>;
 				};
 			};
 		};


### PR DESCRIPTION
The `trailer_partition` is not actually used anywhere, but is to mark
the region as reserved (MCUboot will write to it when swap is done).

When #727 updated flash partitions from PM->DTS migration, this
partition was added, but didn't get updated correctly to account for
parent offset, so it ended up at the wrong position in flash. Harmless
but worth updating for documentation purposes.

Signed-off-by: Noah Pendleton <noah.pendleton@nordicsemi.no>
