### PR TITLE
workflows: build: move cleanup to same node as build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,22 +110,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cleanup:
-    runs-on: build_self_hosted
-    steps:
-      - name: Prune old Docker resources
-        run: docker system prune --force --filter "until=48h"
-
-      - name: Remove stale runner temp entries
-        run: |
-          # GitHub Actions stores per-job temp files under _work/_temp.
-          runner_temp_root="$(dirname "${RUNNER_TEMP}")"
-          find "$runner_temp_root" -mindepth 1 -maxdepth 1 -mmin +2880 \
-            ! -path "$RUNNER_TEMP" \
-            -exec rm -rf {} + 2>/dev/null || true
-
   build:
-    needs: cleanup
     runs-on: build_self_hosted
     container: ghcr.io/zephyrproject-rtos/ci:v0.29.2
     env:


### PR DESCRIPTION
Cleanup is not happening on the same node as build stage. Removing the cleanup job from workflows.
Moving it to ACTIONS_RUNNER_HOOK_JOB_STARTED hook.