### PR TITLE
memfault: ensure module states are included in coredumps

### DIFF
--- a/app/boards/att_flash_partitions.dtsi
+++ b/app/boards/att_flash_partitions.dtsi
@@ -10,7 +10,7 @@
  * 0x0003_0000  slot0_partition (image-0)     (832 KiB)
  *   0x0003_0000  slot0_s_partition           ( 32 KiB)  TF-M secure
  *   0x0003_8000  slot0_ns_partition          (800 KiB)  Zephyr/app non-secure
- *     0x000f_8000  memfault_coredump         ( 16 KiB)  coredump (sub-partition)
+ *     0x000f_4000  memfault_coredump         ( 32 KiB)  coredump (sub-partition)
  *     0x000f_c000  trailer (magic + swap)    ( 16 KiB)  MCUboot swap-status region (sub-partition)
  *
  * Flash layout (flash_ext, 32 MiB external):
@@ -99,10 +99,10 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				storage_partition: memfault_coredump_partition: partition@c0000 {
+				storage_partition: memfault_coredump_partition: partition@bc000 {
 					compatible = "zephyr,mapped-partition";
 					label = "memfault_coredump_partition";
-					reg = <0xc0000 0x4000>;
+					reg = <0x000bc000 0x8000>;
 				};
 
 				/*
@@ -115,7 +115,7 @@
 				trailer_partition: partition@c4000 {
 					compatible = "zephyr,mapped-partition";
 					label = "trailer";
-					reg = <0xc4000 0x4000>;
+					reg = <0x000c4000 0x4000>;
 				};
 			};
 		};

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -160,7 +160,7 @@ CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y
 CONFIG_MEMFAULT_LOGGING_ENABLE=y
 CONFIG_MEMFAULT_LOGGING_RAM_SIZE=4096
 CONFIG_MEMFAULT_EVENT_STORAGE_SIZE=2048
-# Coredump is stored in the dedicated memfault_coredump_partition (16 KiB) that
+# Coredump is stored in the dedicated memfault_coredump_partition (32 KiB) that
 # lives inside slot0 between the app image and MCUboot's reserved tail. See
 # app/boards/att_flash_partitions.dtsi for the layout rationale.
 CONFIG_MEMFAULT_NCS_INTERNAL_FLASH_BACKED_COREDUMP=y

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1404,11 +1404,14 @@ int main(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct main_state main_state;
-
-	main_state.sample_interval_sec = CONFIG_APP_SAMPLING_INTERVAL_SECONDS;
-	main_state.storage_threshold = CONFIG_APP_STORAGE_INITIAL_THRESHOLD;
-	main_state.first_sample_pending = true;
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct main_state main_state = {
+		.sample_interval_sec = CONFIG_APP_SAMPLING_INTERVAL_SECONDS,
+		.storage_threshold = CONFIG_APP_STORAGE_INITIAL_THRESHOLD,
+		.first_sample_pending = true,
+	};
 
 	LOG_DBG("Main has started");
 

--- a/app/src/modules/cloud/cloud.c
+++ b/app/src/modules/cloud/cloud.c
@@ -1269,7 +1269,12 @@ static void cloud_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_CLOUD_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct cloud_state_object cloud_state;
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct cloud_state_object cloud_state = {
+		.backoff_time = CONFIG_APP_CLOUD_BACKOFF_INITIAL_SECONDS,
+	};
 
 	LOG_DBG("Cloud module task started");
 

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -178,6 +178,10 @@ static void env_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_ENVIRONMENTAL_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data")))
 	static struct environmental_state_object environmental_state = {
 		.bme680 = DEVICE_DT_GET(DT_NODELABEL(bme680)),
 	};

--- a/app/src/modules/fota/fota.c
+++ b/app/src/modules/fota/fota.c
@@ -727,7 +727,10 @@ static void fota_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_FOTA_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct fota_state_object fota_state = {
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct fota_state_object fota_state = {
 		.fota_ctx.reboot_fn = fota_reboot,
 		.fota_ctx.status_fn = fota_status,
 	};

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -559,7 +559,10 @@ static void location_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_LOCATION_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct location_state_object location_state;
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct location_state_object location_state;
 
 	LOG_DBG("Location module task started");
 

--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -535,7 +535,10 @@ static void network_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_NETWORK_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct network_state_object network_state;
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct network_state_object network_state;
 
 	task_wdt_id = task_wdt_add(wdt_timeout_ms, network_wdt_callback, (void *)k_current_get());
 	if (task_wdt_id < 0) {

--- a/app/src/modules/power/power.c
+++ b/app/src/modules/power/power.c
@@ -603,7 +603,10 @@ static void power_module_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_POWER_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct power_state_object power_state = {
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct power_state_object power_state = {
 		.charger = DEVICE_DT_GET(DT_NODELABEL(npm1300_charger)),
 	};
 	int32_t chg_status;

--- a/app/src/modules/storage/storage.c
+++ b/app/src/modules/storage/storage.c
@@ -981,9 +981,12 @@ static void storage_thread(void)
 	const uint32_t execution_time_ms =
 		(CONFIG_APP_STORAGE_MSG_PROCESSING_TIMEOUT_SECONDS * MSEC_PER_SEC);
 	const k_timeout_t zbus_wait_ms = K_MSEC(wdt_timeout_ms - execution_time_ms);
-	static struct storage_state storage_state;
-
-	storage_state.buffer_threshold_limit = CONFIG_APP_STORAGE_INITIAL_THRESHOLD;
+	/* Place state object in .data section to ensure it is captured in coredumps
+	 * and can be inspected by external tools during state analysis.
+	 */
+	__attribute__((section(".data"))) static struct storage_state storage_state = {
+		.buffer_threshold_limit = CONFIG_APP_STORAGE_INITIAL_THRESHOLD,
+	};
 
 	LOG_DBG("Storage module task started");
 

--- a/docs/common/tooling_troubleshooting.md
+++ b/docs/common/tooling_troubleshooting.md
@@ -443,6 +443,25 @@ backoff_time        : 60 (0x3C)
 ----------------------------------------
 ```
 
+#### Memory Section Placement for State Objects
+
+All module state objects (main, cloud, location, network, storage) are explicitly placed in the `.data` section of memory using the `__attribute__((section(".data")))` compiler attribute:
+
+```c
+/* Place state object in .data section to ensure it is captured in coredumps
+ * and can be inspected by external tools during state analysis. */
+__attribute__((section(".data"))) static struct main_state main_state = {
+    .sample_interval_sec = CONFIG_APP_SAMPLING_INTERVAL_SECONDS,
+    .storage_threshold = CONFIG_APP_STORAGE_INITIAL_THRESHOLD,
+    .first_sample_pending = true,
+};
+```
+
+By default, Memfault coredumps do not include the `.bss` section.
+Without explicit initialization or attribute placement in the `.data` section, state objects would be placed in `.bss` by the compiler and would not appear in coredumps.
+By placing these objects in `.data`, they are captured in Memfault coredumps and can be inspected by the `inspect_state.py` script when analyzing crashes after the fact.
+This ensures that even in post-mortem debugging scenarios where the device is not under a live debugger, you can still access the complete state of all module state machines at the time of the crash or event.
+
 ## Memfault Remote Debugging
 
 Memfault is enabled by default in all standard firmware builds. Once a device is provisioned to nRF Cloud, it automatically forwards coredumps, LTE and location metrics, and other diagnostic data to the Memfault project linked to your account via nRF Cloud CoAP.

--- a/scripts/inspect_state.py
+++ b/scripts/inspect_state.py
@@ -190,6 +190,9 @@ MODULES = [
 SMF_STATE_SIZE_DEFAULT = 20
 DW_OP_ADDR = 0x03
 
+# Global mapping of channel addresses to channel names
+CHANNEL_MAP: Dict[int, str] = {}
+
 
 # --- DWARF Parsing Helpers ---
 
@@ -210,6 +213,22 @@ def _extract_address_from_location(die: DIE) -> Optional[int]:
     if loc and len(loc.value) > 0 and loc.value[0] == DW_OP_ADDR:
         return int.from_bytes(loc.value[1:], byteorder='little')
     return None
+
+
+def extract_channel_symbols(elffile: Any) -> Dict[int, str]:
+    """Extracts all zbus channel symbols and their addresses from the ELF symbol table."""
+    channel_map: Dict[int, str] = {}
+
+    try:
+        symtab = elffile.get_section_by_name('.symtab')
+        if symtab:
+            for sym in symtab.iter_symbols():
+                if sym.name.endswith('_chan') and sym['st_value'] != 0:
+                    channel_map[sym['st_value']] = sym.name
+    except Exception: # pylint: disable=broad-except
+        pass
+
+    return channel_map
 
 
 class TypeParser:
@@ -392,6 +411,8 @@ def get_symbol_info(dwarfinfo: Any, config: ModuleConfig) -> SymbolInfo:
 
 def analyze_elf(elf_path: Path) -> Dict[str, SymbolInfo]:
     """Parses the ELF file to extract symbol information."""
+    global CHANNEL_MAP  # pylint: disable=global-statement
+
     logger.info(f"Parsing ELF: {elf_path}")
     lookup: Dict[str, SymbolInfo] = {}
 
@@ -403,6 +424,9 @@ def analyze_elf(elf_path: Path) -> Dict[str, SymbolInfo]:
                 return {}
 
             dwarfinfo = elffile.get_dwarf_info()
+
+            # Extract all channel symbols for later resolution
+            CHANNEL_MAP = extract_channel_symbols(elffile)
 
             for module in MODULES:
                 # logger.debug(f"Looking up symbols for {module.name}...")
@@ -447,7 +471,7 @@ def read_smf_state_name(jlink, info: SymbolInfo, current_state_ptr: int) -> str:
     return f"0x{current_state_ptr:X}"
 
 
-def read_value(jlink, address: int, type_info: TypeInfo, indent: int = 0) -> str:
+def read_value(jlink, address: int, type_info: TypeInfo, member_name: Optional[str] = None, indent: int = 0) -> str:
     """Reads and formats a value from memory based on its type."""
     # prefix = " " * indent
     # Unused for now, but kept for future recursive printing if needed
@@ -481,6 +505,10 @@ def read_value(jlink, address: int, type_info: TypeInfo, indent: int = 0) -> str
 
             if val == 0:
                 return "NULL"
+
+            # Check if this is a channel pointer and resolve to name
+            if member_name == "chan" and val in CHANNEL_MAP:
+                return f"{CHANNEL_MAP[val]} (0x{val:08X})"
 
             return f"0x{val:08X}"
 
@@ -543,7 +571,7 @@ def print_struct(jlink, address: int, struct_type: StructType, info: SymbolInfo,
             except Exception: # pylint: disable=broad-except
                 pass
 
-        val_str = read_value(jlink, member_addr, member.type_info)
+        val_str = read_value(jlink, member_addr, member.type_info, member.name)
 
         # Optionally expand nested structs if they are small or interesting?
         # For now, let's keep it flat unless the user drills down, but since this IS the drill down...


### PR DESCRIPTION
Force module state variables to .data section and expand coredump partition from 16 KiB to 32 KiB so they are captured by Memfault coredumps and available in the inspect_state.py debugger.