### PR TITLE
west: bump nrf revision to v3.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v3.4.0-rc2
+      revision: v3.4.0
       import: true


### PR DESCRIPTION
Move off the release candidate now that v3.4.0 is out.