### PR TITLE
Remove cron schedule from ntn-build workflow

### DIFF
--- a/.github/workflows/ntn-build.yaml
+++ b/.github/workflows/ntn-build.yaml
@@ -8,8 +8,6 @@ on:
         description: The ref to build
         required: true
         default: ntn_usecase
-  schedule:
-    - cron: "0 0 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
Removed scheduled cron job from the build workflow.