### PR TITLE
app: modules: network: add logging of LTE_LC_MODEM_EVT_BATTERY_LOW

### DIFF
--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -202,15 +202,36 @@ static void lte_lc_evt_handler(const struct lte_lc_evt *const evt)
 		 * to perform any action. The modem will try to re-attach to the LTE network after
 		 * the 30-minute block.
 		 */
-		if (evt->modem_evt.type == LTE_LC_MODEM_EVT_RESET_LOOP) {
+		switch (evt->modem_evt.type) {
+		case LTE_LC_MODEM_EVT_RESET_LOOP:
 			LOG_WRN("The modem has detected a reset loop!");
 			network_status_notify(NETWORK_MODEM_RESET_LOOP);
-		} else if (evt->modem_evt.type == LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE) {
+
+			break;
+		case LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE:
 			LOG_DBG("LTE_LC_MODEM_EVT_LIGHT_SEARCH_DONE");
 			network_status_notify(NETWORK_LIGHT_SEARCH_DONE);
-		} else if (evt->modem_evt.type == LTE_LC_MODEM_EVT_SEARCH_DONE) {
+
+			break;
+		case LTE_LC_MODEM_EVT_SEARCH_DONE:
 			LOG_DBG("LTE_LC_MODEM_EVT_SEARCH_DONE");
 			network_status_notify(NETWORK_SEARCH_DONE);
+
+			break;
+
+		/* LTE_LC_MODEM_EVT_BATTERY_LOW and LTE_LC_MODEM_EVT_OVERHEATED events are followed
+		 * by a LTE_LC_EVT_PDN_NETWORK_DETACH event. Only log a warning here.
+		 */
+		case LTE_LC_MODEM_EVT_BATTERY_LOW:
+			LOG_WRN("Modem battery low: modem going offline, disconnect expected");
+
+			break;
+		case LTE_LC_MODEM_EVT_OVERHEATED:
+			LOG_WRN("Modem is overheated: modem going offline, disconnect expected");
+
+			break;
+		default:
+			break;
 		}
 
 		break;

--- a/tests/module/network/src/main.c
+++ b/tests/module/network/src/main.c
@@ -643,6 +643,32 @@ void test_modem_fault_work_submit_failure(void)
 	TEST_ASSERT_EQUAL(0, err);
 }
 
+void test_modem_battery_low_no_msg(void)
+{
+	const struct zbus_channel *chan;
+	struct network_msg msg;
+
+	send_mdmev_evt(LTE_LC_MODEM_EVT_BATTERY_LOW);
+
+	/* No zbus message should be published for this event */
+	int err = zbus_sub_wait_msg(&test_subscriber, &chan, &msg, K_MSEC(200));
+
+	TEST_ASSERT_EQUAL(-ENOMSG, err);
+}
+
+void test_modem_overheated_no_msg(void)
+{
+	const struct zbus_channel *chan;
+	struct network_msg msg;
+
+	send_mdmev_evt(LTE_LC_MODEM_EVT_OVERHEATED);
+
+	/* No zbus message should be published for this event */
+	int err = zbus_sub_wait_msg(&test_subscriber, &chan, &msg, K_MSEC(200));
+
+	TEST_ASSERT_EQUAL(-ENOMSG, err);
+}
+
 void test_modem_fault_handler(void)
 {
 	int err;


### PR DESCRIPTION
Add logging of LTE_LC_MODEM_EVT_BATTERY_LOW and
LTE_LC_MODEM_EVT_OVERHEATED events in network module, giving observability of network detachments due to low battery or overheating.

Completes: ATT-423