### PR TITLE
app: memfault: Force Memfault version to match application version

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(app PRIVATE
 # Module source folders
 add_subdirectory(src/modules/network)
 add_subdirectory(src/cbor)
+add_subdirectory(memfault)
 
 # Optional modules
 add_subdirectory_ifdef(CONFIG_APP_BUTTON src/modules/button)

--- a/app/memfault/CMakeLists.txt
+++ b/app/memfault/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC AND
+   NOT "${CONFIG_MEMFAULT_NCS_FW_VERSION}" STREQUAL "${APP_VERSION_STRING}")
+    message(FATAL_ERROR
+        "Memfault firmware version '${CONFIG_MEMFAULT_NCS_FW_VERSION}' "
+        "does not match application version '${APP_VERSION_STRING}'. "
+	"These values must match, use app/VERSION to set both.")
+endif()


### PR DESCRIPTION
Adds cmake level check to ensure Memfault version matches application version, necessary for fota poll requests forwarded from nrfcloud to memfault.