### PR TITLE
docs: add instructions for running on-target tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ venv
 .vscode
 sanity-out*
 twister-out*
-tests/on_target/artifacts/
+tests/on_target/artifacts/*.hex

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -2,9 +2,14 @@
 
 ## Run test locally
 
+Precondition: thingy91x with segger fw on 53.
+
+### Setup
+
+#### Linux (Docker)
+
 NOTE: The tests have been tested on Ubuntu 22.04. For details on how to install Docker please refer to the Docker documentation https://docs.docker.com/engine/install/ubuntu/
 
-### Setup docker
 ```shell
 docker pull ghcr.io/nrfconnect/asset-tracker-template:test-docker-v1.0.2
 cd <path_to_att_dir>
@@ -19,23 +24,34 @@ docker run --rm -it \
 cd /work/asset-tracker-template/tests/on_target
 ```
 
-### Verify nrfutil/jlink works
+Verify the toolchain:
 ```shell
 JLinkExe -V
 nrfutil -V
 ```
 
-### NRF91 tests
-Precondition: thingy91x with segger fw on 53
+#### macOS (natively)
 
-Get device id
+Docker containers on macOS can't access USB debug probes, so run the tests directly on the host.
+Requires an nRF Connect SDK toolchain, `nrfutil`, and a `west`-initialized workspace.
+
+```shell
+source .venv/bin/activate     # activate workspace env
+cd project/tests/on_target    # move to this folder
+pip install -r requirements.txt
+```
+
+### Set env
+
+Get the probe/device serial:
+
 ```shell
 nrfutil device list
 ```
 
-Set env
 ```shell
-export SEGGER=<your_segger>
+export SEGGER=<your_jlink_serial>
+export DUT_DEVICE_TYPE=thingy91x
 ```
 
 Additional fota and memfault envs
@@ -44,7 +60,28 @@ export UUID=<your_imei>
 export NRFCLOUD_API_KEY=<your_nrfcloud_api_key>
 ```
 
-Run desired tests, example commands
+On macOS also set `UART_ID`: port names (`/dev/tty.usbmodem*`) don't contain the SEGGER
+serial that `UART_ID` defaults to, so set it to a substring shared by your DUT's two ports
+(seen in `nrfutil device list`):
+
+```shell
+export UART_ID=<substring of DUT ports, e.g. usbmodem2140>
+```
+
+### Provide firmware artifacts
+
+The tests read firmware from `artifacts/`. In CI this folder is populated automatically, but
+when running locally you must copy your build output into it:
+
+```shell
+cp ../../../build/merged.hex \
+   artifacts/asset-tracker-template-dev-${DUT_DEVICE_TYPE}-nrf91.hex
+cp ../../../build/app/zephyr/zephyr.signed.hex \
+   artifacts/asset-tracker-template-dev-${DUT_DEVICE_TYPE}-update-signed.hex
+```
+
+### Run Tests
+
 ```shell
 # Use -m "not slow" to skip long-running tests (FOTA, memfault, etc.)
 pytest -s -v -m "not slow" tests


### PR DESCRIPTION
Docker sadly doesn't have USB pass through support on macOS. There may be a way with UTM, but most developers likely have the required dependencies installed if they've gotten to this point, so running natively is doable. This commit adds instructions for running the on-target tests locally, including a few improvements:

- Add instructions for copying the test artifacts to the right spot
- Specify `gitignore` rule for the test artifacts only