### PR TITLE
app: modules: cloud: bump watchdog and msg timeouts

### DIFF
--- a/.github/actions/toolchain/action.yml
+++ b/.github/actions/toolchain/action.yml
@@ -1,0 +1,30 @@
+name: "Toolchain"
+description: "Resolve the NCS toolchain version for the pinned sdk-nrf revision"
+outputs:
+  toolchain-version:
+    description: The sdk-nrf-toolchain container tag matching the pinned NCS revision
+    value: ${{ steps.setup.outputs.TOOLCHAIN_VERSION }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        path: asset-tracker-template
+    - name: Find NCS revision
+      shell: bash
+      run: |
+        NCS_REV=$(grep "revision:" asset-tracker-template/west.yml | awk '{print $2}' | xargs)
+        echo "NCS_REV=${NCS_REV}" >> $GITHUB_ENV
+        echo "NCS_REV=${NCS_REV}"
+    - uses: actions/checkout@v6
+      with:
+        path: nrf
+        repository: nrfconnect/sdk-nrf
+        ref: ${{ env.NCS_REV }}
+    - name: Compute toolchain version
+      id: setup
+      shell: bash
+      run: |
+        TOOLCHAIN_VERSION=$(./nrf/scripts/print_toolchain_checksum.sh)
+        echo "TOOLCHAIN_VERSION=${TOOLCHAIN_VERSION}"
+        echo "TOOLCHAIN_VERSION=${TOOLCHAIN_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ concurrency:
 jobs:
   build:
     runs-on: build_self_hosted
-    container: ghcr.io/zephyrproject-rtos/ci:v0.29.2
+    container: ghcr.io/zephyrproject-rtos/ci:v0.29.3
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,11 +103,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      toolchain-version: ${{ steps.setup.outputs.toolchain-version }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/toolchain
+        id: setup
+
   build:
     runs-on: build_self_hosted
-    container: ghcr.io/zephyrproject-rtos/ci:v0.29.3
-    env:
-      CMAKE_PREFIX_PATH: /opt/toolchains
+    needs: setup
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:${{ needs.setup.outputs.toolchain-version }}
+    defaults:
+      run:
+        shell: bash
     outputs:
       run_id: ${{ github.run_id }}
       version: ${{ env.VERSION }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,13 +19,25 @@ permissions:
   contents: read
 
 jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    outputs:
+      toolchain-version: ${{ steps.setup.outputs.toolchain-version }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/toolchain
+        id: setup
+
   build:
     name: Build and analyze
     runs-on: build_self_hosted
-    container: ghcr.io/zephyrproject-rtos/ci:v0.29.3
+    needs: setup
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:${{ needs.setup.outputs.toolchain-version }}
+    defaults:
+      run:
+        shell: bash
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
-      CMAKE_PREFIX_PATH: /opt/toolchains
     steps:
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
@@ -60,7 +72,9 @@ jobs:
             fi
             pip install -r nrf/scripts/requirements-fixed.txt
             apt-get update
-            apt install -y curl ruby-full
+            # `make` is required to build native_sim but is not shipped in the
+            # sdk-nrf-toolchain container (unlike the Zephyr CI image).
+            apt install -y curl ruby-full make
 
       - name: Run tests with ASAN, no Sonarcloud and build_wrapper
         working-directory: asset-tracker-template

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: build_self_hosted
-    container: ghcr.io/zephyrproject-rtos/ci:v0.29.2
+    container: ghcr.io/zephyrproject-rtos/ci:v0.29.3
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
       CMAKE_PREFIX_PATH: /opt/toolchains

--- a/app/src/modules/cloud/Kconfig.cloud
+++ b/app/src/modules/cloud/Kconfig.cloud
@@ -121,7 +121,7 @@ config APP_CLOUD_MESSAGE_QUEUE_SIZE
 
 config APP_CLOUD_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout"
-	default 180
+	default 220
 	help
 	  Timeout in seconds for the cloud module watchdog.
 	  The timeout given in this option covers both:
@@ -135,10 +135,13 @@ config APP_CLOUD_WATCHDOG_TIMEOUT_SECONDS
 
 config APP_CLOUD_MSG_PROCESSING_TIMEOUT_SECONDS
 	int "Maximum message processing time"
-	default 120
+	default 160
 	help
 	  Maximum time allowed for processing a single message in the module's state machine.
 	  The value must be smaller than CONFIG_APP_CLOUD_WATCHDOG_TIMEOUT_SECONDS.
+	  This must cover the worst-case time to connect to nRF Cloud, which is dominated by
+	  the modem's DTLS handshake timeout (TLS_DTLS_HANDSHAKE_TIMEO_123S, 123 seconds),
+	  plus the CoAP authentication exchange and DNS resolution and socket setup overhead.
 
 config APP_CLOUD_STORAGE_BATCH_ITEM_READ_TIMEOUT_MS
 	int "Storage batch item read timeout (ms)"

--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v3.4.0
+      revision: v3.4.1-rc1
       import: true


### PR DESCRIPTION
Cloud connect can take longer than we thought, since the modem's DTLS handshake timeout alone is 123s. Bump the watchdog and message processing timeouts so we don't trip the watchdog during a slow connect, and note why in the Kconfig help text.

Also bump nrf west manifest to v3.4.1-rc1.