### PR TITLE
tests: on_target: update log string matches

### DIFF
--- a/tests/on_target/tests/test_functional/test_shell.py
+++ b/tests/on_target/tests/test_functional/test_shell.py
@@ -26,7 +26,7 @@ def test_shell(dut_cloud, hex_file):
     dut_cloud.uart.xfactoryreset()
 
     patterns_button_press = [
-        "main: connected_sampling_entry: connected_sampling_entry",
+        "main: connected_sampling_entry",
     ]
     patterns_cloud_publish = [
         'Sending on payload channel: {"messageType":"DATA","appId":"donald","data":"duck"',
@@ -48,7 +48,7 @@ def test_shell(dut_cloud, hex_file):
 
     # Wait until connected and ready to sample
     dut_cloud.uart.flush()
-    dut_cloud.uart.wait_for_str("connected_waiting_entry: connected_waiting_entry", timeout=120)
+    dut_cloud.uart.wait_for_str("main: connected_waiting_entry", timeout=120)
 
     # Button press
     dut_cloud.uart.flush()

--- a/tests/on_target/tests/test_provisioning/test_provisioning.py
+++ b/tests/on_target/tests/test_provisioning/test_provisioning.py
@@ -135,8 +135,8 @@ def _wait_for_provisioning_completion_and_cloud_connection(
 
     dut_cloud.uart.wait_for_str(
         [
-            "main: running_run: Device provisioning completed",
-            "cloud: Connected to Cloud",
+            "main: Device provisioning completed",
+            "Connected to Cloud",
         ],
         timeout=timeout,
         start_pos=dut_cloud.uart.get_size(),
@@ -288,7 +288,7 @@ def _run_reprovisioning_expecting_no_commands(dut_cloud):
     dut_cloud.uart.wait_for_str(
         [
             "cloud: No commands from the nRF Provisioning Service to process",
-            "cloud: Connected to Cloud",
+            "Connected to Cloud",
         ],
         timeout=300,
         start_pos=dut_cloud.uart.get_size(),


### PR DESCRIPTION
Log messages changed, so update the expected patterns in the shell and provisioning tests to match the new format.